### PR TITLE
Make sure parsing fails if the path.key is invalid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Made sure parsing fails if the path.key is invalid.
+
 v0.3.6
 
 * Added functionality to sensibly shorten table aliases (requires using the new `setClientModel` function), to handle cases where aliases can grow too large for the database.

--- a/odata-to-abstract-sql.ometajs
+++ b/odata-to-abstract-sql.ometajs
@@ -82,7 +82,7 @@ export ometa OData2AbstractSQL {
 		// We can't use the ReferencedField rule as resource.idField is the model name (using spaces),
 		// not the resource name (with underscores), meaning that the attempts to map fail for a custom id field with spaces.
 		{['ReferencedField', resource.tableAlias, resource.idField]}:referencedIdField
-		PathKey(path, query, resource, referencedIdField, body)?
+		PathKey(path, query, resource, referencedIdField, body)
 
 		(	?(!path.options)
 		|	?(!path.options.$expand)
@@ -110,7 +110,7 @@ export ometa OData2AbstractSQL {
 				-> [referencedField, resource.resourceName]
 			|	{throw new Error('Cannot navigate links')}
 			):aliasedField
-			PathKey(path.link, query, linkResource, referencedField, body)?
+			PathKey(path.link, query, linkResource, referencedField, body)
 			-> query.select.push(aliasedField)
 		|	?(method == 'PUT' || method == 'PUT-INSERT' || method == 'POST' || method == 'PATCH' || method == 'MERGE')
 			ResourceMapping(resource):resourceMapping
@@ -140,16 +140,17 @@ export ometa OData2AbstractSQL {
 	,
 
 	PathKey :path :query :resource :referencedField :body =
-		?path.key
-		// Add the id field value to the body if it doesn't already exist.
-		{resource.resourceName + '.' + resource.idField}:qualifiedIDField
-		(	?(!body[qualifiedIDField] && !body[resource.idField])
-			{body[qualifiedIDField] = path.key}
-		)?
-		(	Number(path.key)
-		|	Text(path.key)
-		):key
-		-> {query.where.push(['Equals', referencedField, key])}
+		(	?(path.key == null)
+		|	// Add the id field value to the body if it doesn't already exist.
+			{resource.resourceName + '.' + resource.idField}:qualifiedIDField
+			(	?(!body[qualifiedIDField] && !body[resource.idField])
+				{body[qualifiedIDField] = path.key}
+			)?
+			(	Number(path.key)
+			|	Text(path.key)
+			):key
+			-> {query.where.push(['Equals', referencedField, key])}
+		)
 	,
 
 	SelectFilter :filter :query :resource =

--- a/test/resource_parsing.coffee
+++ b/test/resource_parsing.coffee
@@ -23,6 +23,11 @@ test '/pilot(1)', (result) ->
 		expect(result).to.be.a.query.that.selects(pilotFields).from('pilot').where(['Equals', ['ReferencedField', 'pilot', 'id'], ['Number', 1]])
 
 
+test '/pilot(0)', (result) ->
+	it 'should select from pilot with id', ->
+		expect(result).to.be.a.query.that.selects(pilotFields).from('pilot').where(['Equals', ['ReferencedField', 'pilot', 'id'], ['Number', 0]])
+
+
 test "/pilot('TextKey')", (result) ->
 	it 'should select from pilot with id', ->
 		expect(result).to.be.a.query.that.selects(pilotFields).from('pilot').where(['Equals', ['ReferencedField', 'pilot', 'id'], ['Text', 'TextKey']])


### PR DESCRIPTION
I was testing a different change which made the path.key invalid but it was just dropping the `WHERE` clause rather than bailing altogether, this change will make sure a SyntaxError is thrown instead if `path.key` exists but is invalid
