### PR TITLE
Add support for definitions and path key filters in insert queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD",
   "dependencies": {
     "@resin/abstract-sql-compiler": "^6.3.6",
-    "@types/lodash": "^4.14.119",
+    "@types/lodash": "^4.14.121",
     "@types/memoizee": "^0.4.2",
     "@types/randomstring": "^1.1.6",
     "lodash": "^4.17.11",
@@ -35,11 +35,11 @@
     "chai-things": "~0.2.0",
     "coffee-script": "~1.12.7",
     "husky": "^1.3.1",
-    "lint-staged": "^8.1.1",
+    "lint-staged": "^8.1.4",
     "mocha": "^5.2.0",
-    "prettier": "^1.16.1",
+    "prettier": "^1.16.4",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
-    "typescript": "^3.2.4"
+    "typescript": "^3.3.3"
   }
 }

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -425,11 +425,11 @@ export class OData2AbstractSQL {
 			}
 			query.select.push(aliasedField);
 		} else if (
-			method == 'PUT' ||
-			method == 'PUT-INSERT' ||
-			method == 'POST' ||
-			method == 'PATCH' ||
-			method == 'MERGE'
+			method === 'PUT' ||
+			method === 'PUT-INSERT' ||
+			method === 'POST' ||
+			method === 'PATCH' ||
+			method === 'MERGE'
 		) {
 			const resourceMapping = this.ResourceMapping(resource);
 			bindVars = this.BindVars(
@@ -444,7 +444,7 @@ export class OData2AbstractSQL {
 			// we make sure to always apply it. This means that the definition will still be applied for these queries
 			if (
 				(hasQueryOpts || resource.definition || pathKeyWhere != null) &&
-				(method == 'POST' || method == 'PUT-INSERT')
+				(method === 'POST' || method === 'PUT-INSERT')
 			) {
 				// For insert statements we need to use an INSERT INTO ... SELECT * FROM (binds) WHERE ... style query
 				const subQuery = new Query();
@@ -493,7 +493,7 @@ export class OData2AbstractSQL {
 					}
 					let found = false;
 					const isTable = (part: any) =>
-						part[0] === 'Table' && part[1] == unionResource.name;
+						part[0] === 'Table' && part[1] === unionResource.name;
 					unionResource.definition.abstractSqlQuery = unionResource.definition.abstractSqlQuery.map(
 						part => {
 							if (part[0] === 'From') {
@@ -548,10 +548,10 @@ export class OData2AbstractSQL {
 		// this is handled when we set the 'Values'
 		if (
 			(hasQueryOpts || resource.definition) &&
-			(method == 'PUT' ||
-				method == 'PATCH' ||
-				method == 'MERGE' ||
-				method == 'DELETE')
+			(method === 'PUT' ||
+				method === 'PATCH' ||
+				method === 'MERGE' ||
+				method === 'DELETE')
 		) {
 			// For update/delete statements we need to use a  style query
 			const subQuery = new Query();
@@ -565,7 +565,7 @@ export class OData2AbstractSQL {
 				referencedIdField,
 				subQuery.compile('SelectQuery') as SelectQueryNode,
 			]);
-		} else if (hasQueryOpts && method == 'GET') {
+		} else if (hasQueryOpts && method === 'GET') {
 			this.AddQueryOptions(resource, path, query);
 		}
 
@@ -579,7 +579,7 @@ export class OData2AbstractSQL {
 		bodyKeys: string[],
 	): BooleanTypeNodes | void {
 		if (path.key != null) {
-			if (method == 'PUT' || method == 'PUT-INSERT' || method == 'POST') {
+			if (method === 'PUT' || method === 'PUT-INSERT' || method === 'POST') {
 				// Add the id field value to the body if it doesn't already exist and we're doing an INSERT or a REPLACE.
 				const qualifiedIDField = resource.resourceName + '.' + resource.idField;
 				if (
@@ -749,7 +749,7 @@ export class OData2AbstractSQL {
 				.reject(field =>
 					_.some(
 						query.select,
-						existingField => _.last(existingField) == field.name,
+						existingField => _.last(existingField) === field.name,
 					),
 				)
 				.map(field => this.AliasSelectField(field.resource, field.name))
@@ -761,7 +761,7 @@ export class OData2AbstractSQL {
 				.reject(fieldName =>
 					_.some(
 						query.select,
-						existingField => _.last(existingField) == fieldName,
+						existingField => _.last(existingField) === fieldName,
 					),
 				)
 				.map(field => this.AliasSelectField(resource, field))

--- a/test/filterby.coffee
+++ b/test/filterby.coffee
@@ -204,10 +204,6 @@ run [['Number', 1]], ->
 				).
 				where(['And'
 					['Equals'
-						['ReferencedField', 'pilot', 'id']
-						['Bind', 0]
-					]
-					['Equals'
 						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane']
 						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id']
 					]
@@ -215,6 +211,10 @@ run [['Number', 1]], ->
 					['Equals'
 						['ReferencedField', 'pilot', 'id']
 						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot']
+					]
+					['Equals'
+						['ReferencedField', 'pilot', 'id']
+						['Bind', 0]
 					]
 				])
 
@@ -426,7 +426,13 @@ run [['Number', 1]], ->
 					]
 				]
 				[	'Where'
-					abstractsql
+					[	'And'
+						abstractsql
+						['Equals'
+							['ReferencedField', 'pilot', 'id']
+							['Bind', 0]
+						]
+					]
 				]
 			).
 			from('pilot')

--- a/test/resource_parsing.coffee
+++ b/test/resource_parsing.coffee
@@ -53,8 +53,8 @@ test '/pilot(1)/licence', (result) ->
 				['licence', 'pilot.licence']
 			).
 			where(['And',
-				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'pilot', 'licence'], ['ReferencedField', 'pilot.licence', 'id']]
+				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 			])
 
 
@@ -67,8 +67,8 @@ test '/licence(1)/is_of__pilot', (result) ->
 				['pilot', 'licence.is of-pilot']
 			).
 			where(['And',
-				['Equals', ['ReferencedField', 'licence', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'licence', 'id'], ['ReferencedField', 'licence.is of-pilot', 'licence']]
+				['Equals', ['ReferencedField', 'licence', 'id'], ['Bind', 0]]
 			])
 
 
@@ -82,9 +82,9 @@ test '/pilot(1)/can_fly__plane/plane', (result) ->
 				['plane', 'pilot.pilot-can fly-plane.plane']
 			).
 			where(['And',
-				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'], ['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id']]
 				['Equals', ['ReferencedField', 'pilot', 'id'], ['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot']]
+				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 			])
 
 
@@ -98,9 +98,9 @@ test '/plane(1)/can_be_flown_by__pilot/pilot', (result) ->
 				['pilot', 'plane.pilot-can fly-plane.pilot']
 			).
 			where(['And',
-				['Equals', ['ReferencedField', 'plane', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'plane.pilot-can fly-plane', 'pilot'], ['ReferencedField', 'plane.pilot-can fly-plane.pilot', 'id']]
 				['Equals', ['ReferencedField', 'plane', 'id'], ['ReferencedField', 'plane.pilot-can fly-plane', 'can fly-plane']]
+				['Equals', ['ReferencedField', 'plane', 'id'], ['Bind', 0]]
 			])
 
 
@@ -121,10 +121,43 @@ test '/pilot(1)', 'PUT', (result) ->
 				'id'
 			).
 			values(
-				['Bind', 'pilot', 'id']
+				'SelectQuery'
+				[	'Select'
+					[	[ 'ReferencedField', 'pilot', 'id' ]
+					]
+				]
+				[	'From'
+					[	'Alias',
+						[	'SelectQuery'
+							[	'Select'
+								[	[ 'Alias', [ 'Cast', 'Null', 'Date Time' ], 'created at' ]
+									[	'Alias',
+										[ 'Cast', [ 'Bind', 'pilot', 'id' ], 'Serial' ],
+										'id'
+									]
+									[ 'Alias', [ 'Cast', 'Null', 'ConceptType' ], 'person' ]
+									[ 'Alias', [ 'Cast', 'Null', 'Boolean' ], 'is experienced' ]
+									[ 'Alias', [ 'Cast', 'Null', 'Short Text' ], 'name' ]
+									[ 'Alias', [ 'Cast', 'Null', 'Integer' ], 'age' ]
+									[ 'Alias', [ 'Cast', 'Null', 'Color' ], 'favourite colour' ]
+									[ 'Alias', [ 'Cast', 'Null', 'ForeignKey' ], 'is on-team' ]
+									[ 'Alias', [ 'Cast', 'Null', 'ForeignKey' ], 'licence' ]
+									[ 'Alias', [ 'Cast', 'Null', 'Date Time' ], 'hire date' ]
+									[ 'Alias', [ 'Cast', 'Null', 'ForeignKey' ], 'was trained by-pilot' ]
+								]
+							]
+						]
+						'pilot'
+					]
+				]
+				[	'Where'
+					[	'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['Bind', 0]
+					]
+				]
 			).
-			from('pilot').
-			where(whereClause)
+			from('pilot')
 		it 'and updates', ->
 			expect(result[2]).to.be.a.query.that.updates.
 			fields(
@@ -198,10 +231,36 @@ test '/pilot__can_fly__plane(1)', 'PUT', (result) ->
 					'id'
 				).
 				values(
-					['Bind', 'pilot-can fly-plane', 'id']
+					'SelectQuery'
+					[	'Select'
+						[	[ 'ReferencedField', 'pilot-can fly-plane', 'id' ]
+						]
+					]
+					[	'From'
+						[	'Alias',
+							[	'SelectQuery'
+								[	'Select'
+									[	[ 'Alias', [ 'Cast', 'Null', 'Date Time' ], 'created at' ]
+										[ 'Alias', [ 'Cast', 'Null', 'ForeignKey' ], 'pilot' ]
+										[ 'Alias', [ 'Cast', 'Null', 'ForeignKey' ], 'can fly-plane' ]
+										[	'Alias',
+											[ 'Cast', ['Bind', 'pilot-can fly-plane', 'id'], 'Serial' ],
+											'id'
+										]
+									]
+								]
+							]
+							'pilot-can fly-plane'
+						]
+					]
+					[	'Where'
+						[	'Equals',
+							['ReferencedField', 'pilot-can fly-plane', 'id'],
+							['Bind', 0]
+						]
+					]
 				).
-				from('pilot-can fly-plane').
-				where(whereClause)
+				from('pilot-can fly-plane')
 		it 'and updates', ->
 			expect(result[2]).to.be.a.query.that.updates.
 				fields(
@@ -260,8 +319,8 @@ test '/pilot(1)/$links/licence(2)', (result) ->
 			selects([['Alias', ['ReferencedField', 'pilot', 'licence'], 'licence']]).
 			from('pilot').
 			where(['And'
-				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'pilot', 'licence'], ['Bind', 1]]
+				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 			])
 
 
@@ -271,8 +330,8 @@ test "/pilot('Peter')/$links/licence('X')", (result) ->
 			selects([['Alias', ['ReferencedField', 'pilot', 'licence'], 'licence']]).
 			from('pilot').
 			where(['And'
-				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'pilot', 'licence'], ['Bind', 1]]
+				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 			])
 
 
@@ -285,8 +344,8 @@ test '/pilot(1)/can_fly__plane/$links/plane', (result) ->
 				['pilot-can fly-plane', 'pilot.pilot-can fly-plane']
 			).
 			where(['And',
-				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'pilot', 'id'], ['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot']]
+				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 			])
 
 
@@ -362,8 +421,8 @@ test '/pilot(5)/licence/$count', (result) ->
 				['licence', 'pilot.licence']
 			).
 			where(['And',
-				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 				['Equals', ['ReferencedField', 'pilot', 'licence'], ['ReferencedField', 'pilot.licence', 'id']]
+				['Equals', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]]
 			])
 
 test '/pilot/$count?$orderby=id asc', (result) ->


### PR DESCRIPTION
So what this basically boils down to is that for insert queries you cannot do
```
INSERT INTO x (...) VALUES (...) WHERE ...
```
and instead have to do the equivalent of
```
INSERT INTO x SELECT ... WHERE ...
```
in order to have a WHERE statement, which we already did for $filter cases but this expands the support to when a resource has a definition, in which case we need to do
```
INSERT INTO x SELECT ... FROM ( SELECT $definition ) x WHERE ...
```
with the $definition have it's `FROM x` replaced by a section along the lines of `SELECT CAST($1, $type) AS $field1, CAST(NULL, $type) AS $field2, ...` to build up the equivalent table from the values we're inserting