### PR TITLE
Add typings support for `ResourceNode`s in join nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "@resin/abstract-sql-compiler": "^6.7.1",
+    "@resin/abstract-sql-compiler": "^6.8.0",
     "@resin/odata-parser": "^1.2.2",
-    "@types/lodash": "^4.14.137",
+    "@types/lodash": "^4.14.138",
     "@types/memoizee": "^0.4.2",
     "@types/randomstring": "^1.1.6",
     "lodash": "^4.17.15",
@@ -34,12 +34,12 @@
     "chai-things": "~0.2.0",
     "coffee-script": "~1.12.7",
     "husky": "^3.0.4",
-    "lint-staged": "^9.2.3",
+    "lint-staged": "^9.2.5",
     "mocha": "^6.2.0",
     "prettier": "^1.18.2",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   },
   "husky": {
     "hooks": {

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -37,13 +37,30 @@ declare module '@resin/abstract-sql-compiler' {
 	interface AbstractSqlTable {
 		definition?: Definition;
 	}
+	type ExtendedFromTypeNodes =
+		| SelectQueryNode
+		| UnionQueryNode
+		| TableNode
+		| ResourceNode
+		| AliasNode<SelectQueryNode | UnionQueryNode | TableNode | ResourceNode>;
 	interface FromNode {
-		1:
-			| SelectQueryNode
-			| UnionQueryNode
-			| TableNode
-			| ResourceNode
-			| AliasNode<SelectQueryNode | UnionQueryNode | TableNode | ResourceNode>;
+		1: ExtendedFromTypeNodes;
+	}
+	interface InnerJoinNode {
+		1: ExtendedFromTypeNodes;
+		2?: OnNode;
+	}
+	interface LeftJoinNode {
+		1: ExtendedFromTypeNodes;
+		2?: OnNode;
+	}
+	interface RightJoinNode {
+		1: ExtendedFromTypeNodes;
+		2?: OnNode;
+	}
+	interface FullJoinNode {
+		1: ExtendedFromTypeNodes;
+		2?: OnNode;
 	}
 }
 


### PR DESCRIPTION
Update abstract-sql-compiler from 6.7.1 to 6.8.0

Change-type: minor