### PR TITLE
Optimise generating resource mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "@resin/abstract-sql-compiler": "^6.8.0",
-    "@resin/odata-parser": "^1.2.2",
+    "@resin/abstract-sql-compiler": "^6.9.0",
+    "@resin/odata-parser": "^1.2.3",
     "@types/lodash": "^4.14.138",
-    "@types/memoizee": "^0.4.2",
+    "@types/memoizee": "^0.4.3",
     "@types/randomstring": "^1.1.6",
     "lodash": "^4.17.15",
     "memoizee": "^0.4.14",
@@ -33,13 +33,13 @@
     "chai": "^4.2.0",
     "chai-things": "~0.2.0",
     "coffee-script": "~1.12.7",
-    "husky": "^3.0.4",
-    "lint-staged": "^9.2.5",
+    "husky": "^3.0.5",
+    "lint-staged": "^9.3.0",
     "mocha": "^6.2.0",
     "prettier": "^1.18.2",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
-    "typescript": "^3.6.2"
+    "typescript": "^3.6.3"
   },
   "husky": {
     "hooks": {

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -729,10 +729,11 @@ export class OData2AbstractSQL {
 		const tableAlias = resource.tableAlias
 			? resource.tableAlias
 			: resource.name;
-		return _(resource.fields)
-			.map((field): [string, string] => [tableAlias, field.fieldName])
-			.keyBy(mapping => sqlNameToODataName(mapping[1]))
-			.value();
+		const resourceMappings: _.Dictionary<[string, string]> = {};
+		for (const { fieldName } of resource.fields) {
+			resourceMappings[sqlNameToODataName(fieldName)] = [tableAlias, fieldName];
+		}
+		return resourceMappings;
 	}
 	ResolveRelationship(resource: string | Resource, relationship: string) {
 		let resourceName;


### PR DESCRIPTION
This improves the time to generate resource mappings by ~40% from my measurements, and they're used for each time we reference a field in the odata so should have a reasonable improvement overall

Change-type: patch