### PR TITLE
Add SBVR Date Time Type to DateTrunc Wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.4.2",
+    "@balena/abstract-sql-compiler": "^7.13.4",
     "@balena/odata-parser": "^2.2.1",
     "@types/lodash": "^4.14.165",
     "@types/memoizee": "^0.4.5",
@@ -50,6 +50,6 @@
     "recursive": true,
     "require": "coffeescript/register",
     "bail": true,
-    "_": "test/resource_parsing.coffee"
+    "_": "test/*.coffee"
   }
 }

--- a/test/chai-sql.coffee
+++ b/test/chai-sql.coffee
@@ -133,6 +133,9 @@ exports.operandToAbstractSQLFactory = (binds = [], defaultResource = 'pilot', de
 				mapping = [alias, _.last(fieldParts)]
 			else
 				mapping = [resource, odataNameToSqlName(operand)]
+			# Data type check by field names that are dates
+			if (mapping[1] == 'created at' || mapping[1] == 'modified at' || mapping[1] == 'hire date')
+				return ['DateTrunc', ['EmbeddedText', 'milliseconds'], ['ReferencedField'].concat(mapping)]
 			return ['ReferencedField'].concat(mapping)
 		if Array.isArray(operand)
 			return operandToAbstractSQL(operand...)


### PR DESCRIPTION
JS Date format has only milliseconds precision, postgresql stores
TIMESTAMPS with microseconds precission. Comparisions may fail,
when giving millisecond JS dates but comparing on microseconds.

Change-type: patch
Signed-off-by: fisehara <harald@balena.io>