### PR TITLE
Use `SELECT *, $computedFields` for adding computed fields

### DIFF
--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -1536,14 +1536,19 @@ export class OData2AbstractSQL {
 			}
 			if (resource.fields.some((f) => f.computed != null)) {
 				const computedFieldQuery = new Query();
-				computedFieldQuery.select = resource.fields.map((field) =>
-					this.AliasSelectField(
-						resource,
-						sqlNameToODataName(field.fieldName),
-						field.computed,
-						field.fieldName,
-					),
-				);
+				computedFieldQuery.select = [
+					['Field', '*'],
+					...resource.fields
+						.filter(({ computed }) => computed != null)
+						.map((field) =>
+							this.AliasSelectField(
+								resource,
+								sqlNameToODataName(field.fieldName),
+								field.computed,
+								field.fieldName,
+							),
+						),
+				];
 				computedFieldQuery.fromResource(
 					this,
 					{


### PR DESCRIPTION
This reduces the size of the generated SQL when computed fields are
included and as such helps to make it more readable

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-devops/threads/emYlPWgGShfJlVd1PitXgyMvBbG