### PR TITLE
Respect `modifyFields`/`modifyName` in the table definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.22.0",
+    "@balena/abstract-sql-compiler": "^7.25.0",
     "@balena/odata-parser": "^2.4.2",
     "@types/lodash": "^4.14.189",
     "@types/memoizee": "^0.4.8",

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -150,6 +150,7 @@ class Query {
 			bindVarsLength: number;
 		} = odataToAbstractSql,
 		bypassDefinition?: boolean,
+		isModifyOperation?: boolean,
 	): void {
 		const tableRef = odataToAbstractSql.getTableReference(
 			resource,
@@ -157,6 +158,7 @@ class Query {
 			args.bindVarsLength,
 			bypassDefinition,
 			resource.tableAlias,
+			isModifyOperation,
 		);
 		this.from.push(tableRef);
 	}
@@ -400,7 +402,13 @@ export class OData2AbstractSQL {
 		const query = new Query();
 		// For non-GETs we bypass definitions for the actual update/insert as we need to write to the base table
 		const bypassDefinition = method !== 'GET';
-		query.fromResource(this, resource, this, bypassDefinition);
+		query.fromResource(
+			this,
+			resource,
+			this,
+			bypassDefinition,
+			bypassDefinition,
+		);
 
 		// We can't use the ReferencedField rule as resource.idField is the model name (using spaces),
 		// not the resource name (with underscores), meaning that the attempts to map fail for a custom id field with spaces.
@@ -468,7 +476,7 @@ export class OData2AbstractSQL {
 			method === 'PATCH' ||
 			method === 'MERGE'
 		) {
-			const resourceMapping = this.ResourceMapping(resource);
+			const resourceMapping = this.ResourceMapping(resource, true);
 			bindVars = this.BindVars(
 				method,
 				bodyKeys,
@@ -488,22 +496,33 @@ export class OData2AbstractSQL {
 				subQuery.select = bindVars.map(
 					(bindVar): ReferencedFieldNode => [
 						'ReferencedField',
-						resource.tableAlias,
+						'$insert',
 						bindVar[0],
 					],
 				);
 
+				subQuery.from.push([
+					'Alias',
+					[
+						'SelectQuery',
+						[
+							'Select',
+							(resource.modifyFields ?? resource.fields).map(
+								(field): AliasNode<CastNode> => {
+									const alias = field.fieldName;
+									const bindVar = bindVars?.find((v) => v[0] === alias);
+									const value = bindVar?.[1] ?? ['Null'];
+									return ['Alias', ['Cast', value, field.dataType], alias];
+								},
+							),
+						],
+					],
+					'$insert',
+				]);
+
 				const bindVarSelectQuery: SelectQueryNode = [
 					'SelectQuery',
-					[
-						'Select',
-						resource.fields.map((field): AliasNode<CastNode> => {
-							const alias = field.fieldName;
-							const bindVar = bindVars?.find((v) => v[0] === alias);
-							const value = bindVar?.[1] ?? ['Null'];
-							return ['Alias', ['Cast', value, field.dataType], alias];
-						}),
-					],
+					['Select', [['ReferencedField', '$insert', '*']]],
 				];
 
 				const unionResource = { ...resource };
@@ -516,20 +535,29 @@ export class OData2AbstractSQL {
 						abstractSql: bindVarSelectQuery,
 					};
 				} else {
-					unionResource.definition = {
-						...convertToModernDefinition(unionResource.definition),
-					};
-					if (unionResource.definition.abstractSql[0] !== 'SelectQuery') {
+					const rewrittenBindVars: ModernDefinition['binds'] = [];
+					const definition: Definition = (unionResource.definition =
+						this.rewriteDefinition(
+							unionResource.definition,
+							rewrittenBindVars,
+							0,
+						));
+					definition.binds = rewrittenBindVars;
+
+					if (
+						definition.abstractSql[0] !== 'SelectQuery' &&
+						definition.abstractSql[0] !== 'Table'
+					) {
 						throw new Error(
-							'Only select query definitions supported for inserts',
+							'Only SelectQuery or Table definitions supported for inserts',
 						);
 					}
-
+					const tableName = unionResource.modifyName ?? unionResource.name;
 					const isTableBeingModified = (part: any): part is TableNode =>
-						isTableNode(part) && part[1] === unionResource.name;
+						isTableNode(part) && part[1] === tableName;
 
-					if (isTableBeingModified(unionResource.definition.abstractSql)) {
-						unionResource.definition.abstractSql = bindVarSelectQuery;
+					if (isTableBeingModified(definition.abstractSql)) {
+						definition.abstractSql = bindVarSelectQuery;
 					} else {
 						let found = false;
 						const replaceInsertTableNodeWithBinds = (
@@ -538,10 +566,7 @@ export class OData2AbstractSQL {
 							if (isFromNode(part)) {
 								if (isTableBeingModified(part[1])) {
 									found = true;
-									return [
-										'From',
-										['Alias', bindVarSelectQuery, unionResource.name],
-									];
+									return ['From', ['Alias', bindVarSelectQuery, tableName]];
 								} else if (isAliasNode(part[1])) {
 									const [, aliasedNode, alias] = part[1];
 									if (isTableBeingModified(aliasedNode)) {
@@ -563,10 +588,9 @@ export class OData2AbstractSQL {
 							}
 							return part;
 						};
-						unionResource.definition.abstractSql =
-							unionResource.definition.abstractSql.map(
-								replaceInsertTableNodeWithBinds,
-							) as SelectQueryNode;
+						definition.abstractSql = definition.abstractSql.map(
+							replaceInsertTableNodeWithBinds,
+						) as SelectQueryNode;
 						if (!found) {
 							throw new Error(
 								'Could not replace table entry in definition for insert',
@@ -574,14 +598,16 @@ export class OData2AbstractSQL {
 						}
 					}
 				}
+				const whereQuery = new Query();
 				if (hasQueryOpts) {
-					this.AddQueryOptions(resource, path, subQuery);
+					this.AddQueryOptions(resource, path, whereQuery);
 				}
-				subQuery.fromResource(this, unionResource);
+				whereQuery.fromResource(this, unionResource, this, false, true);
 				addPathKey = false;
 				if (pathKeyWhere != null) {
-					subQuery.where.push(pathKeyWhere);
+					whereQuery.where.push(pathKeyWhere);
 				}
+				subQuery.where.push(['Exists', whereQuery.compile('SelectQuery')]);
 
 				query.extras.push([
 					'Values',
@@ -592,7 +618,7 @@ export class OData2AbstractSQL {
 			}
 		} else if (path.count) {
 			this.AddCountField(path, query);
-		} else {
+		} else if (method === 'GET') {
 			this.AddSelectFields(path, query, resource);
 		}
 
@@ -809,10 +835,17 @@ export class OData2AbstractSQL {
 			throw e;
 		}
 	}
-	ResourceMapping(resource: Resource): Dictionary<[string, string]> {
+	ResourceMapping(
+		resource: Resource,
+		modifyFields = false,
+	): Dictionary<[string, string]> {
 		const tableAlias = resource.tableAlias ?? resource.name;
 		const resourceMappings: Dictionary<[string, string]> = {};
-		for (const { fieldName } of resource.fields) {
+		const fields =
+			modifyFields === true && resource.modifyFields
+				? resource.modifyFields
+				: resource.fields;
+		for (const { fieldName } of fields) {
 			resourceMappings[sqlNameToODataName(fieldName)] = [tableAlias, fieldName];
 		}
 		return resourceMappings;
@@ -1512,6 +1545,7 @@ export class OData2AbstractSQL {
 		bindVarsLength: number,
 		bypassDefinition: boolean = false,
 		tableAlias?: string,
+		isModifyOperation?: boolean,
 	): FromTypeNodes | AliasNode<FromTypeNodes> {
 		const maybeAlias = (
 			tableRef: FromTypeNodes | AliasNode<FromTypeNodes>,
@@ -1570,7 +1604,12 @@ export class OData2AbstractSQL {
 				return maybeAlias(computedFieldQuery.compile('SelectQuery'));
 			}
 		}
-		return maybeAlias(['Table', resource.name]);
+		return maybeAlias([
+			'Table',
+			isModifyOperation && resource.modifyName
+				? resource.modifyName
+				: resource.name,
+		]);
 	}
 
 	rewriteDefinition(

--- a/test/expand.js
+++ b/test/expand.js
@@ -213,7 +213,7 @@ test('/pilot?$expand=licence($filter=id eq 1)', function (result) {
 			);
 		})
 		.value();
-	return it('should select from pilot.*, licence.*', () =>
+	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -256,7 +256,7 @@ test('/pilot?$expand=licence($filter=is_of__pilot/id eq 1)', function (result) {
 			);
 		})
 		.value();
-	return it('should select from pilot.*, licence.*', () =>
+	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -275,7 +275,7 @@ test('/pilot?$expand=licence($orderby=id)', function (result) {
 		.find({ 0: 'SelectQuery' })
 		.value()
 		.push(['OrderBy', ['DESC', ['ReferencedField', 'pilot.licence', 'id']]]);
-	return it('should select from pilot.*, licence.*', () =>
+	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -294,7 +294,7 @@ test('/pilot?$expand=licence($top=10)', function (result) {
 		.find({ 0: 'SelectQuery' })
 		.value()
 		.push(['Limit', ['Number', 10]]);
-	return it('should select from pilot.*, licence.*', () =>
+	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -313,7 +313,7 @@ test('/pilot?$expand=licence($skip=10)', function (result) {
 		.find({ 0: 'SelectQuery' })
 		.value()
 		.push(['Offset', ['Number', 10]]);
-	return it('should select from pilot.*, licence.*', () =>
+	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -334,7 +334,7 @@ test('/pilot?$expand=licence($select=id)', function (result) {
 		.value();
 	select[1] = _.filter(select[1], { 2: 'id' });
 
-	return it('should select from pilot.*, licence.*', () =>
+	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -442,7 +442,7 @@ test('/pilot?$expand=licence/$count($filter=id gt 5)', function (result) {
 			);
 		})
 		.value();
-	return it('should select from pilot.*, count(*) licence for id gt 5', () =>
+	it('should select from pilot.*, count(*) licence for id gt 5', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
 				agg,
@@ -504,7 +504,7 @@ test('/pilot?$expand=licence/$count($top=5)', (result) =>
 	})();
 
 	const url = '/pilot?' + expandString;
-	return test(url, function (result) {
+	test(url, function (result) {
 		var recurse = function (i, parentAlias) {
 			let aliasedFields;
 			const alias = shortenAlias(`${parentAlias}.trained-pilot`);
@@ -525,7 +525,7 @@ test('/pilot?$expand=licence/$count($top=5)', (result) =>
 				fields: aliasedFields,
 			});
 		};
-		return it('should select from pilot.*, aggregated pilot', () =>
+		it('should select from pilot.*, aggregated pilot', () =>
 			expect(result)
 				.to.be.a.query.that.selects([
 					recurse(recursions, 'pilot'),

--- a/test/filterby.js
+++ b/test/filterby.js
@@ -126,21 +126,21 @@ const operandTest = (lhs, op, rhs) =>
 	run(function () {
 		const { odata, abstractsql } = createExpression(lhs, op, rhs);
 		test('/pilot?$filter=' + odata, (result) =>
-			it('should select from pilot where "' + odata + '"', () =>
+			it('should select from pilot where "' + odata + '"', () => {
 				expect(result)
 					.to.be.a.query.that.selects(pilotFields)
 					.from('pilot')
-					.where(abstractsql),
-			),
+					.where(abstractsql);
+			}),
 		);
 
 		return test('/pilot/$count?$filter=' + odata, (result) =>
-			it('should count(*) from pilot where "' + odata + '"', () =>
+			it('should count(*) from pilot where "' + odata + '"', () => {
 				expect(result)
 					.to.be.a.query.that.selects($count)
 					.from('pilot')
-					.where(abstractsql),
-			),
+					.where(abstractsql);
+			}),
 		);
 	});
 
@@ -148,7 +148,7 @@ const navigatedOperandTest = (lhs, op, rhs) =>
 	run(function () {
 		const { odata, abstractsql } = createExpression(lhs, op, rhs);
 		test('/pilot?$filter=' + odata, (result) =>
-			it('should select from pilot where "' + odata + '"', () =>
+			it('should select from pilot where "' + odata + '"', () => {
 				expect(result)
 					.to.be.a.query.that.selects(pilotFields)
 					.from('pilot', ['licence', 'pilot.licence'])
@@ -160,11 +160,11 @@ const navigatedOperandTest = (lhs, op, rhs) =>
 							['ReferencedField', 'pilot.licence', 'id'],
 						],
 						abstractsql,
-					]),
-			),
+					]);
+			}),
 		);
 		return test('/pilot/$count?$filter=' + odata, (result) =>
-			it('should count(*) from pilot where "' + odata + '"', () =>
+			it('should count(*) from pilot where "' + odata + '"', () => {
 				expect(result)
 					.to.be.a.query.that.selects($count)
 					.from('pilot', ['licence', 'pilot.licence'])
@@ -176,8 +176,8 @@ const navigatedOperandTest = (lhs, op, rhs) =>
 							['ReferencedField', 'pilot.licence', 'id'],
 						],
 						abstractsql,
-					]),
-			),
+					]);
+			}),
 		);
 	});
 
@@ -243,7 +243,7 @@ run(function () {
 		10,
 	);
 	return test('/pilot?$filter=' + odata, (result) =>
-		it('should select from pilot where "' + odata + '"', () =>
+		it('should select from pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.selects(pilotFields)
 				.from('pilot', ['pilot-can fly-plane', 'pilot.pilot-can fly-plane'])
@@ -255,15 +255,15 @@ run(function () {
 						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
 					],
 					abstractsql,
-				]),
-		),
+				]);
+		}),
 	);
 });
 
 run(function () {
 	const { odata } = createExpression('created_at', 'gt', new Date());
 	return test('/pilot?$filter=' + odata, (result) =>
-		it('should select from pilot where "' + odata + '"', () =>
+		it('should select from pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.selects(pilotFields)
 				.where([
@@ -274,15 +274,15 @@ run(function () {
 						['ReferencedField', 'pilot', 'created at'],
 					],
 					['Bind', 0],
-				]),
-		),
+				]);
+		}),
 	);
 });
 
 run(function () {
 	const { odata } = createExpression('created_at', 'gt', new Date());
 	return test('/pilot(1)/licence?$filter=' + odata, (result) =>
-		it('should select from the licence of pilot with id and created_at greaterThan', () =>
+		it('should select from the licence of pilot with id and created_at greaterThan', () => {
 			expect(result)
 				.to.be.a.query.that.selects(aliasFields('pilot', licenceFields))
 				.from('pilot', ['licence', 'pilot.licence'])
@@ -307,7 +307,8 @@ run(function () {
 						['ReferencedField', 'pilot', 'id'],
 						['Bind', 0],
 					],
-				])),
+				]);
+		}),
 	);
 });
 
@@ -317,8 +318,8 @@ run([['Number', 1]], function () {
 		'eq',
 		10,
 	);
-	return test('/pilot(1)/can_fly__plane?$filter=' + odata, (result) =>
-		it('should select from pilot where "' + odata + '"', () =>
+	return test('/pilot(1)/can_fly__plane?$filter=' + odata, (result) => {
+		it('should select from pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.selects(
 					aliasFields('pilot', pilotCanFlyPlaneFields),
@@ -346,9 +347,9 @@ run([['Number', 1]], function () {
 						['ReferencedField', 'pilot', 'id'],
 						['Bind', 0],
 					],
-				]),
-		),
-	);
+				]);
+		});
+	});
 });
 
 run(function () {
@@ -372,24 +373,12 @@ run(function () {
 		],
 		abstractsql,
 	];
-	const insertTest = (result) =>
+	const insertTest = (result) => {
 		expect(result)
 			.to.be.a.query.that.inserts.fields('name')
 			.values(
 				'SelectQuery',
-				['Select', [['ReferencedField', 'pilot', 'name']]],
-				[
-					'From',
-					[
-						'Alias',
-						['Table', 'pilot-can fly-plane'],
-						'pilot.pilot-can fly-plane',
-					],
-				],
-				[
-					'From',
-					['Alias', ['Table', 'plane'], 'pilot.pilot-can fly-plane.plane'],
-				],
+				['Select', [['ReferencedField', '$insert', 'name']]],
 				[
 					'From',
 					[
@@ -422,12 +411,50 @@ run(function () {
 								],
 							],
 						],
-						'pilot',
+						'$insert',
 					],
 				],
-				['Where', filterWhere],
+				[
+					'Where',
+					[
+						'Exists',
+						[
+							'SelectQuery',
+							['Select', []],
+							[
+								'From',
+								[
+									'Alias',
+									['Table', 'pilot-can fly-plane'],
+									'pilot.pilot-can fly-plane',
+								],
+							],
+							[
+								'From',
+								[
+									'Alias',
+									['Table', 'plane'],
+									'pilot.pilot-can fly-plane.plane',
+								],
+							],
+							[
+								'From',
+								[
+									'Alias',
+									[
+										'SelectQuery',
+										['Select', [['ReferencedField', '$insert', '*']]],
+									],
+									'pilot',
+								],
+							],
+							['Where', filterWhere],
+						],
+					],
+				],
 			)
 			.from('pilot');
+	};
 	const updateWhere = [
 		'In',
 		['ReferencedField', 'pilot', 'id'],
@@ -452,7 +479,7 @@ run(function () {
 	];
 
 	test('/pilot?$filter=' + odata, (result) =>
-		it('should select from pilot where "' + odata + '"', () =>
+		it('should select from pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.selects(pilotFields)
 				.from('pilot', ['pilot-can fly-plane', 'pilot.pilot-can fly-plane'])
@@ -469,18 +496,18 @@ run(function () {
 						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
 					],
 					abstractsql,
-				]),
-		),
+				]);
+		}),
 	);
 
 	test(`/pilot?$filter=${odata}`, 'PATCH', { name: 'Peter' }, (result) =>
-		it('should update pilot where "' + odata + '"', () =>
+		it('should update pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.updates.fields('name')
 				.values(['Bind', 'pilot', 'name'])
 				.from('pilot')
-				.where(updateWhere),
-		),
+				.where(updateWhere);
+		}),
 	);
 
 	test(`/pilot?$filter=${odata}`, 'POST', { name: 'Peter' }, (result) =>
@@ -489,8 +516,9 @@ run(function () {
 
 	test(`/pilot?$filter=${odata}`, 'PUT', { name: 'Peter' }, (result) =>
 		describe(`should select from pilot where '${odata}'`, function () {
-			it('should be an upsert', () =>
-				expect(result).to.be.a.query.that.upserts);
+			it('should be an upsert', () => {
+				expect(result).to.be.a.query.that.upserts;
+			});
 			it('that inserts', () => insertTest(result[1]));
 			return it('and updates', () =>
 				expect(result[2])
@@ -528,7 +556,7 @@ run(function () {
 	);
 
 	return test('/pilot?$filter=' + odata, 'DELETE', (result) =>
-		it('should delete from pilot where "' + odata + '"', () =>
+		it('should delete from pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.deletes.from('pilot')
 				.where([
@@ -572,15 +600,15 @@ run(function () {
 							],
 						],
 					],
-				]),
-		),
+				]);
+		}),
 	);
 });
 
 run([['Number', 1]], function () {
 	const name = 'Peter';
 	const { odata, abstractsql } = createExpression('name', 'eq', `'${name}'`);
-	const insertTest = (result) =>
+	const insertTest = (result) => {
 		expect(result)
 			.to.be.a.query.that.inserts.fields('id', 'name')
 			.values(
@@ -588,8 +616,8 @@ run([['Number', 1]], function () {
 				[
 					'Select',
 					[
-						['ReferencedField', 'pilot', 'id'],
-						['ReferencedField', 'pilot', 'name'],
+						['ReferencedField', '$insert', 'id'],
+						['ReferencedField', '$insert', 'name'],
 					],
 				],
 				[
@@ -624,23 +652,45 @@ run([['Number', 1]], function () {
 								],
 							],
 						],
-						'pilot',
+						'$insert',
 					],
 				],
 				[
 					'Where',
 					[
-						'And',
-						abstractsql,
+						'Exists',
 						[
-							'IsNotDistinctFrom',
-							['ReferencedField', 'pilot', 'id'],
-							['Bind', 0],
+							'SelectQuery',
+							['Select', []],
+							[
+								'From',
+								[
+									'Alias',
+									[
+										'SelectQuery',
+										['Select', [['ReferencedField', '$insert', '*']]],
+									],
+									'pilot',
+								],
+							],
+							[
+								'Where',
+								[
+									'And',
+									abstractsql,
+									[
+										'IsNotDistinctFrom',
+										['ReferencedField', 'pilot', 'id'],
+										['Bind', 0],
+									],
+								],
+							],
 						],
 					],
 				],
 			)
 			.from('pilot');
+	};
 	const updateWhere = [
 		'And',
 		['IsNotDistinctFrom', ['ReferencedField', 'pilot', 'id'], ['Bind', 0]],
@@ -663,12 +713,13 @@ run([['Number', 1]], function () {
 	);
 
 	test('/pilot(1)?$filter=' + odata, 'PATCH', { name }, (result) =>
-		it('should update the pilot with id 1', () =>
+		it('should update the pilot with id 1', () => {
 			expect(result)
 				.to.be.a.query.that.updates.fields('name')
 				.values(['Bind', 'pilot', 'name'])
 				.from('pilot')
-				.where(updateWhere)),
+				.where(updateWhere);
+		}),
 	);
 
 	return test('/pilot(1)?$filter=' + odata, 'PUT', { name }, (result) =>
@@ -676,7 +727,7 @@ run([['Number', 1]], function () {
 			it('should be an upsert', () =>
 				expect(result).to.be.a.query.that.upserts);
 			it('that inserts', () => insertTest(result[1]));
-			return it('and updates', () =>
+			return it('and updates', () => {
 				expect(result[2])
 					.to.be.a.query.that.updates.fields(
 						'created at',
@@ -707,7 +758,8 @@ run([['Number', 1]], function () {
 						'Default',
 					)
 					.from('pilot')
-					.where(updateWhere));
+					.where(updateWhere);
+			});
 		}),
 	);
 });
@@ -716,13 +768,12 @@ run(function () {
 	const licence = 1;
 	const { odata, abstractsql } = createExpression('licence/id', 'eq', licence);
 	return test('/pilot?$filter=' + odata, 'POST', { licence }, (result) =>
-		it('should insert into pilot where "' + odata + '"', () =>
+		it('should insert into pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.inserts.fields('licence')
 				.values(
 					'SelectQuery',
-					['Select', [['ReferencedField', 'pilot', 'licence']]],
-					['From', ['Alias', ['Table', 'licence'], 'pilot.licence']],
+					['Select', [['ReferencedField', '$insert', 'licence']]],
 					[
 						'From',
 						[
@@ -755,24 +806,46 @@ run(function () {
 									],
 								],
 							],
-							'pilot',
+							'$insert',
 						],
 					],
 					[
 						'Where',
 						[
-							'And',
+							'Exists',
 							[
-								'Equals',
-								['ReferencedField', 'pilot', 'licence'],
-								['ReferencedField', 'pilot.licence', 'id'],
+								'SelectQuery',
+								['Select', []],
+								['From', ['Alias', ['Table', 'licence'], 'pilot.licence']],
+								[
+									'From',
+									[
+										'Alias',
+										[
+											'SelectQuery',
+											['Select', [['ReferencedField', '$insert', '*']]],
+										],
+										'pilot',
+									],
+								],
+								[
+									'Where',
+									[
+										'And',
+										[
+											'Equals',
+											['ReferencedField', 'pilot', 'licence'],
+											['ReferencedField', 'pilot.licence', 'id'],
+										],
+										abstractsql,
+									],
+								],
 							],
-							abstractsql,
 						],
 					],
 				)
-				.from('pilot'),
-		),
+				.from('pilot');
+		}),
 	);
 });
 
@@ -784,14 +857,13 @@ run(function () {
 		'eq',
 		`'${name}'`,
 	);
-	return test(`/pilot?$filter=${odata}`, 'POST', { licence }, (result) =>
-		it('should insert into pilot where "' + odata + '"', () =>
+	test(`/pilot?$filter=${odata}`, 'POST', { licence }, (result) =>
+		it('should insert into pilot where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.inserts.fields('licence')
 				.values(
 					'SelectQuery',
-					['Select', [['ReferencedField', 'pilot', 'licence']]],
-					['From', ['Alias', ['Table', 'licence'], 'pilot.licence']],
+					['Select', [['ReferencedField', '$insert', 'licence']]],
 					[
 						'From',
 						[
@@ -824,24 +896,46 @@ run(function () {
 									],
 								],
 							],
-							'pilot',
+							'$insert',
 						],
 					],
 					[
 						'Where',
 						[
-							'And',
+							'Exists',
 							[
-								'Equals',
-								['ReferencedField', 'pilot', 'licence'],
-								['ReferencedField', 'pilot.licence', 'id'],
+								'SelectQuery',
+								['Select', []],
+								['From', ['Alias', ['Table', 'licence'], 'pilot.licence']],
+								[
+									'From',
+									[
+										'Alias',
+										[
+											'SelectQuery',
+											['Select', [['ReferencedField', '$insert', '*']]],
+										],
+										'pilot',
+									],
+								],
+								[
+									'Where',
+									[
+										'And',
+										[
+											'Equals',
+											['ReferencedField', 'pilot', 'licence'],
+											['ReferencedField', 'pilot.licence', 'id'],
+										],
+										abstractsql,
+									],
+								],
 							],
-							abstractsql,
 						],
 					],
 				)
-				.from('pilot'),
-		),
+				.from('pilot');
+		}),
 	);
 });
 
@@ -1105,11 +1199,12 @@ const lambdaTest = function (methodName) {
 				methodName +
 				"(d:d/plane/name eq 'Concorde')",
 			(result) =>
-				it('should select from pilot where ...', () =>
+				it('should select from pilot where ...', () => {
 					expect(result)
 						.to.be.a.query.that.selects(pilotFields)
 						.from('pilot')
-						.where(where)),
+						.where(where);
+				}),
 		);
 
 		return test(
@@ -1117,11 +1212,12 @@ const lambdaTest = function (methodName) {
 				methodName +
 				"(d:d/plane/name eq 'Concorde')",
 			(result) =>
-				it('should select count(*) from pilot where ...', () =>
+				it('should select count(*) from pilot where ...', () => {
 					expect(result)
 						.to.be.a.query.that.selects($count)
 						.from('pilot')
-						.where(where)),
+						.where(where);
+				}),
 		);
 	});
 
@@ -1182,11 +1278,12 @@ const lambdaTest = function (methodName) {
 				methodName +
 				"(d:d/name eq 'Concorde')",
 			(result) =>
-				it('should select from pilot where ...', () =>
+				it('should select from pilot where ...', () => {
 					expect(result)
 						.to.be.a.query.that.selects(pilotFields)
 						.from('pilot', ['pilot-can fly-plane', 'pilot.pilot-can fly-plane'])
-						.where(where)),
+						.where(where);
+				}),
 		);
 
 		return test(
@@ -1194,11 +1291,12 @@ const lambdaTest = function (methodName) {
 				methodName +
 				"(d:d/name eq 'Concorde')",
 			(result) =>
-				it('should select count(*) from pilot where ...', () =>
+				it('should select count(*) from pilot where ...', () => {
 					expect(result)
 						.to.be.a.query.that.selects($count)
 						.from('pilot', ['pilot-can fly-plane', 'pilot.pilot-can fly-plane'])
-						.where(where)),
+						.where(where);
+				}),
 		);
 	});
 };
@@ -1224,12 +1322,12 @@ run(function () {
 		'POST',
 		{ favourite_colour: favouriteColour },
 		(result) =>
-			it('should insert into team where "' + odata + '"', () =>
+			it('should insert into team where "' + odata + '"', () => {
 				expect(result)
 					.to.be.a.query.that.inserts.fields('favourite colour')
 					.values(
 						'SelectQuery',
-						['Select', [['ReferencedField', 'team', 'favourite colour']]],
+						['Select', [['ReferencedField', '$insert', 'favourite colour']]],
 						[
 							'From',
 							[
@@ -1249,13 +1347,34 @@ run(function () {
 										],
 									],
 								],
-								'team',
+								'$insert',
 							],
 						],
-						['Where', abstractsql],
+						[
+							'Where',
+							[
+								'Exists',
+								[
+									'SelectQuery',
+									['Select', []],
+									[
+										'From',
+										[
+											'Alias',
+											[
+												'SelectQuery',
+												['Select', [['ReferencedField', '$insert', '*']]],
+											],
+											'team',
+										],
+									],
+									['Where', abstractsql],
+								],
+							],
+						],
 					)
-					.from('team'),
-			),
+					.from('team');
+			}),
 	);
 });
 
@@ -1267,7 +1386,7 @@ run(function () {
 		`'${planeName}'`,
 	);
 	return test('/team?$filter=' + odata, (result) =>
-		it('should select from team where "' + odata + '"', () =>
+		it('should select from team where "' + odata + '"', () => {
 			expect(result)
 				.to.be.a.query.that.selects(teamFields)
 				.from(
@@ -1306,7 +1425,7 @@ run(function () {
 						],
 					],
 					abstractsql,
-				]),
-		),
+				]);
+		}),
 	);
 });

--- a/test/resource_parsing.js
+++ b/test/resource_parsing.js
@@ -214,12 +214,12 @@ test('/pilot(1)', 'PUT', (result) =>
 			['Bind', 0],
 		];
 		it('should be an upsert', () => expect(result).to.be.a.query.that.upserts);
-		it('that inserts', () =>
+		it('that inserts', () => {
 			expect(result[1])
 				.to.be.a.query.that.inserts.fields('id')
 				.values(
 					'SelectQuery',
-					['Select', [['ReferencedField', 'pilot', 'id']]],
+					['Select', [['ReferencedField', '$insert', 'id']]],
 					[
 						'From',
 						[
@@ -252,20 +252,42 @@ test('/pilot(1)', 'PUT', (result) =>
 									],
 								],
 							],
-							'pilot',
+							'$insert',
 						],
 					],
 					[
 						'Where',
 						[
-							'IsNotDistinctFrom',
-							['ReferencedField', 'pilot', 'id'],
-							['Bind', 0],
+							'Exists',
+							[
+								'SelectQuery',
+								['Select', []],
+								[
+									'From',
+									[
+										'Alias',
+										[
+											'SelectQuery',
+											['Select', [['ReferencedField', '$insert', '*']]],
+										],
+										'pilot',
+									],
+								],
+								[
+									'Where',
+									[
+										'IsNotDistinctFrom',
+										['ReferencedField', 'pilot', 'id'],
+										['Bind', 0],
+									],
+								],
+							],
 						],
 					],
 				)
-				.from('pilot'));
-		return it('and updates', () =>
+				.from('pilot');
+		});
+		it('and updates', () => {
 			expect(result[2])
 				.to.be.a.query.that.updates.fields(
 					'created at',
@@ -296,7 +318,8 @@ test('/pilot(1)', 'PUT', (result) =>
 					'Default',
 				)
 				.from('pilot')
-				.where(whereClause));
+				.where(whereClause);
+		});
 	}),
 );
 
@@ -321,7 +344,7 @@ test('/pilot(1)', 'PUT', (result) =>
 		{ is_experienced: true, favourite_colour: null },
 		testFunc,
 	);
-	return test(
+	test(
 		'/pilot(1)',
 		'MERGE',
 		{ is_experienced: true, favourite_colour: null },
@@ -348,7 +371,7 @@ test('/pilot__can_fly__plane(1)', 'DELETE', (result) =>
 			])),
 );
 
-test('/pilot__can_fly__plane(1)', 'PUT', (result) =>
+test('/pilot__can_fly__plane(1)', 'PUT', (result) => {
 	describe('should upsert the pilot__can_fly__plane with id 1', function () {
 		const whereClause = [
 			'IsNotDistinctFrom',
@@ -356,12 +379,12 @@ test('/pilot__can_fly__plane(1)', 'PUT', (result) =>
 			['Bind', 0],
 		];
 		it('should be an upsert', () => expect(result).to.be.a.query.that.upserts);
-		it('that inserts', () =>
+		it('that inserts', () => {
 			expect(result[1])
 				.to.be.a.query.that.inserts.fields('id')
 				.values(
 					'SelectQuery',
-					['Select', [['ReferencedField', 'pilot-can fly-plane', 'id']]],
+					['Select', [['ReferencedField', '$insert', 'id']]],
 					[
 						'From',
 						[
@@ -387,20 +410,42 @@ test('/pilot__can_fly__plane(1)', 'PUT', (result) =>
 									],
 								],
 							],
-							'pilot-can fly-plane',
+							'$insert',
 						],
 					],
 					[
 						'Where',
 						[
-							'IsNotDistinctFrom',
-							['ReferencedField', 'pilot-can fly-plane', 'id'],
-							['Bind', 0],
+							'Exists',
+							[
+								'SelectQuery',
+								['Select', []],
+								[
+									'From',
+									[
+										'Alias',
+										[
+											'SelectQuery',
+											['Select', [['ReferencedField', '$insert', '*']]],
+										],
+										'pilot-can fly-plane',
+									],
+								],
+								[
+									'Where',
+									[
+										'IsNotDistinctFrom',
+										['ReferencedField', 'pilot-can fly-plane', 'id'],
+										['Bind', 0],
+									],
+								],
+							],
 						],
 					],
 				)
-				.from('pilot-can fly-plane'));
-		return it('and updates', () =>
+				.from('pilot-can fly-plane');
+		});
+		it('and updates', () => {
 			expect(result[2])
 				.to.be.a.query.that.updates.fields(
 					'created at',
@@ -415,13 +460,14 @@ test('/pilot__can_fly__plane(1)', 'PUT', (result) =>
 					'id',
 				])
 				.from('pilot-can fly-plane')
-				.where(whereClause));
-	}),
-);
+				.where(whereClause);
+		});
+	});
+});
 
 (function () {
 	const testFunc = (result) =>
-		it('should update the pilot__can_fly__plane with id 1', () =>
+		it('should update the pilot__can_fly__plane with id 1', () => {
 			expect(result)
 				.to.be.a.query.that.updates.fields('pilot')
 				.values(['Bind', 'pilot-can fly-plane', 'pilot'])
@@ -430,9 +476,10 @@ test('/pilot__can_fly__plane(1)', 'PUT', (result) =>
 					'IsNotDistinctFrom',
 					['ReferencedField', 'pilot-can fly-plane', 'id'],
 					['Bind', 0],
-				]));
+				]);
+		});
 	test('/pilot__can_fly__plane(1)', 'PATCH', { pilot: 2 }, testFunc);
-	return test('/pilot__can_fly__plane(1)', 'MERGE', { pilot: 2 }, testFunc);
+	test('/pilot__can_fly__plane(1)', 'MERGE', { pilot: 2 }, testFunc);
 })();
 
 test(


### PR DESCRIPTION
This is intended to be used to target tables differently for reads vs
writes, eg where you might read from a view/definition but want to
write to a physical table instead

Change-type: minor