### PR TITLE
Add support for `/$count` with nested `$filter` in $orderby & $orderby

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "BSD",
   "dependencies": {
     "@balena/abstract-sql-compiler": "^7.20.0",
-    "@balena/odata-parser": "^2.2.9",
+    "@balena/odata-parser": "^2.4.0",
     "@types/lodash": "^4.14.182",
     "@types/memoizee": "^0.4.8",
     "@types/string-hash": "^1.1.1",

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -1199,7 +1199,17 @@ export class OData2AbstractSQL {
 		} else if (prop.count) {
 			const query = new Query();
 			query.select.push(['Count', '*']);
-			this.AddNavigation(query, this.defaultResource!, prop.name);
+			const aliasedResource = this.AddNavigation(
+				query,
+				this.defaultResource!,
+				prop.name,
+			);
+			if (prop.options?.$filter) {
+				const defaultResource = this.defaultResource;
+				this.defaultResource = aliasedResource;
+				this.SelectFilter(prop.options.$filter, query, aliasedResource);
+				this.defaultResource = defaultResource;
+			}
 			return query.compile('SelectQuery');
 		} else {
 			return { resource: this.defaultResource!, name: prop.name };

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { operandToAbstractSQLFactory, pilotFields } from './chai-sql';
+import {
+	operandToAbstractSQLFactory,
+	pilotFields,
+	teamFields,
+} from './chai-sql';
 import test from './test';
 
 const operandToAbstractSQL = operandToAbstractSQLFactory();
@@ -83,3 +87,133 @@ test('/pilot?$orderby=can_fly__plane/plane/id asc', (result) =>
 
 test.skip('/pilot?$orderby=favourite_colour/red', () =>
 	it("should order by how red the pilot's favourite colour is"));
+
+test('/pilot?$orderby=trained__pilot/$count asc', (result) => {
+	it('should order pilots by how many other pilots they have trained', () => {
+		expect(result)
+			.to.be.a.query.that.selects(pilotFields)
+			.from('pilot')
+			.orderby([
+				'ASC',
+				[
+					'SelectQuery',
+					['Select', [['Count', '*']]],
+					['From', ['Alias', ['Table', 'pilot'], 'pilot.trained-pilot']],
+					[
+						'Where',
+						[
+							'Equals',
+							['ReferencedField', 'pilot', 'id'],
+							[
+								'ReferencedField',
+								'pilot.trained-pilot',
+								'was trained by-pilot',
+							],
+						],
+					],
+				],
+			]);
+	});
+});
+
+test('/pilot?$orderby=trained__pilot/$count($filter=is_experienced eq true) asc', (result) => {
+	it('should order pilots by how many other pilots that they have trained are now experienced', () => {
+		expect(result)
+			.to.be.a.query.that.selects(pilotFields)
+			.from('pilot')
+			.orderby([
+				'ASC',
+				[
+					'SelectQuery',
+					['Select', [['Count', '*']]],
+					['From', ['Alias', ['Table', 'pilot'], 'pilot.trained-pilot']],
+					[
+						'Where',
+						[
+							'And',
+							[
+								'Equals',
+								['ReferencedField', 'pilot', 'id'],
+								[
+									'ReferencedField',
+									'pilot.trained-pilot',
+									'was trained by-pilot',
+								],
+							],
+							[
+								'IsNotDistinctFrom',
+								['ReferencedField', 'pilot.trained-pilot', 'is experienced'],
+								['Bind', 0],
+							],
+						],
+					],
+				],
+			]);
+	});
+});
+
+test('/team?$orderby=includes__pilot/$count desc', (result) => {
+	it('should order teams by the number of pilots', () => {
+		expect(result)
+			.to.be.a.query.that.selects(teamFields)
+			.from('team')
+			.orderby([
+				'DESC',
+				[
+					'SelectQuery',
+					['Select', [['Count', '*']]],
+					['From', ['Alias', ['Table', 'pilot'], 'team.includes-pilot']],
+					[
+						'Where',
+						[
+							'Equals',
+							[
+								'ReferencedField',
+								'team',
+								// That's b/c it's the team's `Database ID Field`
+								'favourite colour',
+							],
+							['ReferencedField', 'team.includes-pilot', 'is on-team'],
+						],
+					],
+				],
+			]);
+	});
+});
+
+test('/team?$orderby=includes__pilot/$count($filter=is_experienced eq true) desc', (result) => {
+	it('should order teams by the number of pilots that are experienced', () => {
+		expect(result)
+			.to.be.a.query.that.selects(teamFields)
+			.from('team')
+			.orderby([
+				'DESC',
+				[
+					'SelectQuery',
+					['Select', [['Count', '*']]],
+					['From', ['Alias', ['Table', 'pilot'], 'team.includes-pilot']],
+					[
+						'Where',
+						[
+							'And',
+							[
+								'Equals',
+								[
+									'ReferencedField',
+									'team',
+									// That's b/c it's the team's `Database ID Field`
+									'favourite colour',
+								],
+								['ReferencedField', 'team.includes-pilot', 'is on-team'],
+							],
+							[
+								'IsNotDistinctFrom',
+								['ReferencedField', 'team.includes-pilot', 'is experienced'],
+								['Bind', 0],
+							],
+						],
+					],
+				],
+			]);
+	});
+});


### PR DESCRIPTION
Change-type: minor
Depends-on: https://github.com/balena-io-modules/odata-parser/pull/64
See: https://github.com/balena-io/pinejs/issues/577
See: https://jel.ly.fish/thread-f02087f0-7415-42ac-9b54-75fd10fd0c5c
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>