### PR TITLE
Always replace the table being modified in definitions, ignoring aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "npm run prepare",
     "test": "mocha && npm run lint",
     "prepublish": "require-npm4-to-publish",
-    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\" && tsc"
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"; tsc"
   },
   "repository": "https://github.com/balena-io-modules/odata-to-abstract-sql.git",
   "author": "",


### PR DESCRIPTION
This avoids issues where the aliases may not map up, particularly if the definition was generated and may have automatic aliases, eg if using the result of an odata-to-abstract-sql generation

Change-type: patch