### PR TITLE
Add computed fields only once

### DIFF
--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -105,6 +105,20 @@ const generateClientModel = function (input) {
 const sbvrModel = fs.readFileSync(require.resolve('./model.sbvr'), 'utf8');
 export const clientModel = generateClientModel(sbvrModel);
 
+clientModel.tables['copilot'].fields.push({
+	fieldName: 'is blocked',
+	dataType: 'Boolean',
+	// The cast is needed because AbstractSqlQuery cannot express a constant value.
+	computed: ['Boolean', false],
+});
+
+clientModel.tables['copilot'].fields.push({
+	fieldName: 'rank',
+	dataType: 'Text',
+	// The cast is needed because AbstractSqlQuery cannot express a constant value.
+	computed: ['Text', 'Junior'],
+});
+
 const odataNameToSqlName = (odataName) =>
 	odataName.replace(/__/g, '-').replace(/_/g, ' ');
 
@@ -360,3 +374,14 @@ export let teamFields = [
 ];
 
 export let $count = [['Alias', ['Count', '*'], '$count']];
+
+export let copilotFields = [
+	['Alias', ['ReferencedField', 'copilot', 'created at'], 'created_at'],
+	['Alias', ['ReferencedField', 'copilot', 'modified at'], 'modified_at'],
+	['ReferencedField', 'copilot', 'id'],
+	['ReferencedField', 'copilot', 'person'],
+	['ReferencedField', 'copilot', 'assists-pilot'],
+	['Alias', ['ReferencedField', 'copilot', 'is blocked'], 'is_blocked'],
+	['ReferencedField', 'copilot', 'rank'],
+
+];

--- a/test/filterby.js
+++ b/test/filterby.js
@@ -1429,3 +1429,97 @@ run(function () {
 		}),
 	);
 });
+
+test(`/copilot?$select=id,rank&$filter=rank eq 'major'`, (result) =>
+	it(`should get and filter copilot on computed field rank`, () => {
+		expect(result).to.be.a.query.to.deep.equal([
+			'SelectQuery',
+			[
+				'Select',
+				[
+					['ReferencedField', 'copilot', 'id'],
+					['ReferencedField', 'copilot', 'rank'],
+				],
+			],
+			[
+				'From',
+				[
+					'Alias',
+					[
+						'SelectQuery',
+						[
+							'Select',
+							[
+								['Field', '*'],
+								['Alias', ['Boolean', false], 'is blocked'],
+								['Alias', ['Text', 'Junior'], 'rank'],
+							],
+						],
+						['From', ['Table', 'copilot']],
+					],
+					'copilot',
+				],
+			],
+			[
+				'Where',
+				[
+					'IsNotDistinctFrom',
+					['ReferencedField', 'copilot', 'rank'],
+					['Bind', 0],
+				],
+			],
+		]);
+	}));
+
+test.only(
+	`/copilot?$select=id,rank&$filter=rank eq 'major'`,
+	'PATCH',
+	{ assists__pilot: 1 },
+	(result) =>
+		it(`should PATCH copilot based on filtered computed field rank`, () => {
+			expect(result).to.be.a.query.to.deep.equal([
+				'UpdateQuery',
+				['From', ['Table', 'copilot']],
+				[
+					'Where',
+					[
+						'In',
+						['ReferencedField', 'copilot', 'id'],
+						[
+							'SelectQuery',
+							['Select', [['ReferencedField', 'copilot', 'id']]],
+							[
+								'From',
+								[
+									'Alias',
+									[
+										'SelectQuery',
+										[
+											'Select',
+											[
+												['Field', '*'],
+												['Alias', ['Boolean', false], 'is blocked'],
+												['Alias', ['Text', 'Junior'], 'rank'],
+											],
+										],
+										['From', ['Table', 'copilot']],
+									],
+									'copilot',
+								],
+							],
+							[
+								'Where',
+								[
+									'IsNotDistinctFrom',
+									['ReferencedField', 'copilot', 'rank'],
+									['Bind', 0],
+								],
+							],
+						],
+					],
+				],
+				['Fields', ['assists-pilot']],
+				['Values', [['Bind', 'copilot', 'assists__pilot']]],
+			]);
+		}),
+);

--- a/test/model.sbvr
+++ b/test/model.sbvr
@@ -58,3 +58,9 @@ Fact type:  pilot has hire date
 Fact type:  pilot1 was trained by pilot2
 	Synonymous Form: pilot2 trained pilot1
 	Necessity: each pilot was trained by exactly one pilot
+
+Term:	copilot
+	Concept Type:	pilot
+
+Fact Type: copilot assists pilot
+	Necessity: each copilot assists at most one pilot

--- a/test/select.js
+++ b/test/select.js
@@ -152,3 +152,76 @@ test('/pilot?$select=can_fly__plane/plane/id', (result) =>
 					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
 				],
 			])));
+
+test('/copilot?$select=*', (result) =>
+	it('should select * from copilot', () =>
+		expect(result).to.be.a.query.to.deep.equal([
+			'SelectQuery',
+			[
+				'Select',
+				[
+					['Alias', ['ReferencedField', 'copilot', 'created at'], 'created_at'],
+					[
+						'Alias',
+						['ReferencedField', 'copilot', 'modified at'],
+						'modified_at',
+					],
+					['ReferencedField', 'copilot', 'id'],
+					['ReferencedField', 'copilot', 'pilot'],
+					['Alias', ['ReferencedField', 'copilot', 'is blocked'], 'is_blocked'],
+					['ReferencedField', 'copilot', 'rank'],
+				],
+			],
+			[
+				'From',
+				[
+					'Alias',
+					[
+						'SelectQuery',
+						[
+							'Select',
+							[
+								['Field', '*'],
+								['Alias', ['Boolean', false], 'is blocked'],
+								['Alias', ['Text', 'Junior'], 'rank'],
+							],
+						],
+						['From', ['Table', 'copilot']],
+					],
+					'copilot',
+				],
+			],
+		])));
+
+test('/copilot?$select=id,is_blocked,rank', (result) =>
+	it('should select * from copilot', () =>
+		expect(result).to.be.a.query.to.deep.equal([
+			'SelectQuery',
+			[
+				'Select',
+				[
+					['ReferencedField', 'copilot', 'id'],
+					['Alias', ['ReferencedField', 'copilot', 'is blocked'], 'is_blocked'],
+					['ReferencedField', 'copilot', 'rank'],
+				],
+			],
+			[
+				'From',
+				[
+					'Alias',
+					[
+						'SelectQuery',
+						[
+							'Select',
+							[
+								['Field', '*'],
+								['Alias', ['Boolean', false], 'is blocked'],
+								['Alias', ['Text', 'Junior'], 'rank'],
+							],
+						],
+						['From', ['Table', 'copilot']],
+					],
+					'copilot',
+				],
+			],
+		])));


### PR DESCRIPTION
All other occurrences should use as referenceField or Alias

As the computedFields are only compiled into the query once and afterwards referenced or aliased into OData field name, it  reduces example query 
`Running GET /resin/device(uuid=@uuid)?$select=id,is_frozen&@uuid='<uuid>'`
from 10001 bytes SQL statement to 5409 bytes statement.

Change-type: minor