### PR TITLE
Support bind references as boolean types

### DIFF
--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -1109,6 +1109,8 @@ export class OData2AbstractSQL {
 							}
 							throw new SyntaxError(`Boolean does not support ${type}`);
 					}
+				} else if (isBindReference(match)) {
+					return this.Bind(match);
 				} else {
 					try {
 						return this.ReferencedProperty(match);

--- a/test/filterby.js
+++ b/test/filterby.js
@@ -241,6 +241,20 @@ operandTest('name', 'in', '(1,2)');
 })();
 
 run(function () {
+	const odata = operandToOData(true);
+	const abstractsql = operandToAbstractSQL(true);
+
+	return test('/pilot?$filter=' + odata, (result) =>
+		it('should select from pilot where "' + odata + '"', () => {
+			expect(result)
+				.to.be.a.query.that.selects(pilotFields)
+				.from('pilot')
+				.where(abstractsql);
+		}),
+	);
+});
+
+run(function () {
 	const { odata, abstractsql } = createExpression(
 		'can_fly__plane/id',
 		'eq',


### PR DESCRIPTION
This allows things like `$filter=true` and `$filter=x/any(y:true)` to work

Change-type: minor