### PR TITLE
Properly error when using fields of a partial index as an alternate key

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^9.0.4",
+    "@balena/abstract-sql-compiler": "^9.1.4",
     "@balena/odata-parser": "^3.0.3",
     "@types/lodash": "^4.14.202",
     "@types/memoizee": "^0.4.11",

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -790,7 +790,8 @@ export class OData2AbstractSQL {
 				) &&
 				!resource.indexes.some((index) => {
 					return (
-						(index.type === 'UNIQUE' || index.type === 'PRIMARY KEY') &&
+						((index.type === 'UNIQUE' && index.predicate == null) ||
+							index.type === 'PRIMARY KEY') &&
 						sqlFieldNames.length === index.fields.length &&
 						_.isEqual(index.fields.slice().sort(), sqlFieldNames)
 					);


### PR DESCRIPTION
Update @balena/abstract-sql-compiler from 9.0.4 to 9.1.4

Change-type: patch