### PR TITLE
Support PUT/PATCH/DELETE requests on resources with a translated ID field

### DIFF
--- a/test/paging.js
+++ b/test/paging.js
@@ -36,7 +36,10 @@ test('/pilot?$top=5&$skip=100', 'PATCH', { name }, (result) =>
 				['ReferencedField', 'pilot', 'id'],
 				[
 					'SelectQuery',
-					['Select', [['ReferencedField', 'pilot', 'id']]],
+					[
+						'Select',
+						[['Alias', ['ReferencedField', 'pilot', 'id'], '$modifyid']],
+					],
 					['From', ['Table', 'pilot']],
 					['Limit', ['Number', 5]],
 					['Offset', ['Number', 100]],
@@ -52,7 +55,10 @@ test('/pilot?$top=5&$skip=100', 'DELETE', (result) =>
 				['ReferencedField', 'pilot', 'id'],
 				[
 					'SelectQuery',
-					['Select', [['ReferencedField', 'pilot', 'id']]],
+					[
+						'Select',
+						[['Alias', ['ReferencedField', 'pilot', 'id'], '$modifyid']],
+					],
 					['From', ['Table', 'pilot']],
 					['Limit', ['Number', 5]],
 					['Offset', ['Number', 100]],


### PR DESCRIPTION
Change-type: minor
See: https://balena.fibery.io/Work/Project/Server-side-pagination-for-devices-Cycle-4-673
See: https://balena.fibery.io/Work/Task/odata-to-abstract-sql-Support-PUT-PATCH-DELETE-requests-on-resources-with-a-translated-ID-field-2089
See: https://balena.zulipchat.com/#narrow/stream/403752-channel.2Fsupport-help/topic/Error.20500.20on.20should.20be.20running.20release/near/464744246
See: https://gist.github.com/thgreasi/7cf6eba5634e813a7e34a0832724de36