### PR TITLE
Support number references as boolean types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "license": "BSD",
   "dependencies": {
     "@balena/abstract-sql-compiler": "^9.2.0",
-    "@balena/odata-parser": "^3.0.8",
-    "@types/lodash": "^4.17.7",
+    "@balena/odata-parser": "^3.1.0",
+    "@types/lodash": "^4.17.10",
     "@types/memoizee": "^0.4.11",
     "@types/string-hash": "^1.1.3",
     "lodash": "^4.17.21",
@@ -27,20 +27,20 @@
   },
   "devDependencies": {
     "@balena/lf-to-abstract-sql": "^5.0.2",
-    "@balena/lint": "^8.2.7",
+    "@balena/lint": "^8.2.8",
     "@balena/sbvr-parser": "^1.4.6",
     "@balena/sbvr-types": "^7.1.3",
-    "@types/chai": "^4.3.18",
+    "@types/chai": "^4.3.20",
     "@types/chai-things": "0.0.38",
-    "@types/mocha": "^10.0.7",
+    "@types/mocha": "^10.0.8",
     "chai": "^4.5.0",
     "chai-things": "~0.2.0",
-    "husky": "^9.1.5",
-    "lint-staged": "^15.2.9",
+    "husky": "^9.1.6",
+    "lint-staged": "^15.2.10",
     "mocha": "^10.7.3",
     "require-npm4-to-publish": "^1.0.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.2"
   },
   "mocha": {
     "reporter": "spec",

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -1469,6 +1469,8 @@ export class OData2AbstractSQL {
 					}
 					throw new SyntaxError(`${method} is not a number function`);
 			}
+		} else if (isBindReference(match)) {
+			return this.Bind(match);
 		} else if (optional) {
 			return;
 		} else {

--- a/test/expand.js
+++ b/test/expand.js
@@ -299,7 +299,7 @@ test('/pilot?$expand=licence($top=10)', function (result) {
 		.find({ 2: 'pilot.licence' })
 		.find({ 0: 'SelectQuery' })
 		.value()
-		.push(['Limit', ['Number', 10]]);
+		.push(['Limit', ['Bind', 0]]);
 	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([
@@ -318,7 +318,7 @@ test('/pilot?$expand=licence($skip=10)', function (result) {
 		.find({ 2: 'pilot.licence' })
 		.find({ 0: 'SelectQuery' })
 		.value()
-		.push(['Offset', ['Number', 10]]);
+		.push(['Offset', ['Bind', 0]]);
 	it('should select from pilot.*, licence.*', () =>
 		expect(result)
 			.to.be.a.query.that.selects([

--- a/test/paging.js
+++ b/test/paging.js
@@ -7,22 +7,22 @@ test('/pilot?$top=5', (result) =>
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
 			.from('pilot')
-			.limit(['Number', 5])));
+			.limit(['Bind', 0])));
 
 test('/pilot?$skip=100', (result) =>
 	it('should select from pilot offset by 100', () =>
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
 			.from('pilot')
-			.offset(['Number', 100])));
+			.offset(['Bind', 0])));
 
 test('/pilot?$top=5&$skip=100', (result) =>
 	it('should select from pilot limited by 5 and offset by 100', () =>
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
 			.from('pilot')
-			.limit(['Number', 5])
-			.offset(['Number', 100])));
+			.limit(['Bind', 0])
+			.offset(['Bind', 1])));
 
 const name = 'Peter';
 test('/pilot?$top=5&$skip=100', 'PATCH', { name }, (result) =>
@@ -41,8 +41,8 @@ test('/pilot?$top=5&$skip=100', 'PATCH', { name }, (result) =>
 						[['Alias', ['ReferencedField', 'pilot', 'id'], '$modifyid']],
 					],
 					['From', ['Table', 'pilot']],
-					['Limit', ['Number', 5]],
-					['Offset', ['Number', 100]],
+					['Limit', ['Bind', 0]],
+					['Offset', ['Bind', 1]],
 				],
 			])),
 );
@@ -60,8 +60,8 @@ test('/pilot?$top=5&$skip=100', 'DELETE', (result) =>
 						[['Alias', ['ReferencedField', 'pilot', 'id'], '$modifyid']],
 					],
 					['From', ['Table', 'pilot']],
-					['Limit', ['Number', 5]],
-					['Offset', ['Number', 100]],
+					['Limit', ['Bind', 0]],
+					['Offset', ['Bind', 1]],
 				],
 			])),
 );


### PR DESCRIPTION
This allows things like `$top=10` and `$skip=5` to work whilst being converted to bind variables

Update @balena/odata-parser from 3.0.8 to 3.1.0

Change-type: minor