### PR TITLE
Fix OrderBy to use LEFT JOIN instead of INNER JOIN

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BSD",
   "dependencies": {
     "@balena/abstract-sql-compiler": "^10.2.0",
-    "@balena/odata-parser": "^4.1.0",
+    "@balena/odata-parser": "^4.2.1",
     "@types/lodash": "^4.17.10",
     "@types/memoizee": "^0.4.11",
     "@types/string-hash": "^1.1.3",

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -87,12 +87,11 @@ import type {
 	BindReference,
 	GenericPropertyPath,
 	PropertyPath,
+	MethodCall,
 } from '@balena/odata-parser';
 export type { ODataBinds, ODataQuery, SupportedMethod };
 
 type InternalSupportedMethod = Exclude<SupportedMethod, 'MERGE'> | 'PUT-INSERT';
-
-type JoinType = 'Join' | 'LeftJoin' | 'RightJoin';
 
 type RequiredAbstractSqlModelSubset = Pick<
 	AbstractSqlModel,
@@ -260,7 +259,6 @@ class Query {
 	joinResource(
 		odataToAbstractSql: OData2AbstractSQL,
 		resource: AliasedResource,
-		type: JoinType,
 		condition: BooleanTypeNodes,
 		args: {
 			extraBindVars: ODataBinds;
@@ -276,7 +274,7 @@ class Query {
 			resource.tableAlias,
 			undefined,
 		);
-		const joinNode: JoinTypeNodes = [type, tableRef, ['On', condition]];
+		const joinNode: JoinTypeNodes = ['LeftJoin', tableRef, ['On', condition]];
 		this.joins.push(joinNode);
 	}
 	addNestedFieldSelect(fieldName: string, fieldNameAlias: string): void {
@@ -905,12 +903,12 @@ export class OData2AbstractSQL {
 		throw new SyntaxError(`Could not match bind reference`);
 	}
 	SelectFilter(filter: FilterOption, query: Query, resource: Resource) {
-		this.AddExtraFroms(query, resource, filter);
+		this.AddJoins(query, resource, filter);
 		const where = this.BooleanMatch(filter);
 		query.where.push(where);
 	}
 	OrderBy(orderby: OrderByOption, query: Query, resource: Resource) {
-		this.AddJoins(query, resource, orderby.properties, 'LeftJoin');
+		this.AddJoins(query, resource, orderby.properties);
 		query.extras.push([
 			'OrderBy',
 			...this.OrderByProperties(orderby.properties),
@@ -1059,7 +1057,7 @@ export class OData2AbstractSQL {
 			Parameters<OData2AbstractSQL['AliasSelectField']>
 		>;
 		if (path.options?.$select?.properties) {
-			this.AddExtraFroms(query, resource, path.options.$select.properties);
+			this.AddJoins(query, resource, path.options.$select.properties);
 			odataFieldNames = path.options.$select.properties.map((prop: any) => {
 				const field = this.Property(prop) as {
 					resource: Resource;
@@ -1330,7 +1328,7 @@ export class OData2AbstractSQL {
 			this.resourceAliases[lambda.identifier] = resource;
 
 			this.defaultResource = resource;
-			this.AddExtraFroms(query, resource, lambda.expression);
+			this.AddJoins(query, resource, lambda.expression);
 			const filter = this.BooleanMatch(lambda.expression);
 			if (lambda.method === 'any') {
 				query.where.push(filter);
@@ -1687,12 +1685,19 @@ export class OData2AbstractSQL {
 			],
 		};
 	}
-	AddExtraFroms(query: Query, parentResource: Resource, match: any) {
+	AddJoins(
+		query: Query,
+		parentResource: Resource,
+		// This can be any node that odata-parser returns
+		match:
+			| (GenericPropertyPath<PropertyPath> | MethodCall[1])
+			| Array<GenericPropertyPath<PropertyPath> | MethodCall[1]>,
+	) {
 		// TODO: try removing
 		try {
 			if (Array.isArray(match)) {
 				match.forEach((v) => {
-					this.AddExtraFroms(query, parentResource, v);
+					this.AddJoins(query, parentResource, v);
 				});
 			} else {
 				let nextProp = match;
@@ -1700,6 +1705,8 @@ export class OData2AbstractSQL {
 				while (
 					// tslint:disable-next-line:no-conditional-assignment
 					(prop = nextProp) &&
+					// Confirm that prop is indeed a GenericPropertyPath<PropertyPath>
+					'name' in prop &&
 					prop.name &&
 					prop.property?.name
 				) {
@@ -1708,19 +1715,42 @@ export class OData2AbstractSQL {
 					if (resourceAlias) {
 						parentResource = resourceAlias;
 					} else {
-						parentResource = this.AddNavigation(
+						parentResource = this.AddJoinNavigation(
 							query,
 							parentResource,
 							prop.name,
 						);
 					}
 				}
-				if (nextProp?.args) {
-					this.AddExtraFroms(query, parentResource, prop.args);
+				if (nextProp != null && 'args' in nextProp && nextProp.args != null) {
+					this.AddJoins(query, parentResource, nextProp.args);
 				}
 			}
 		} catch {
 			// ignore
+		}
+	}
+	AddJoinNavigation(
+		query: Query,
+		resource: Resource,
+		extraResource: string,
+	): AliasedResource {
+		const navigation = this.NavigateResources(resource, extraResource);
+		if (
+			!query.joins.some((join) => {
+				const from = join[1];
+				return (
+					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
+					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
+				);
+			})
+		) {
+			query.joinResource(this, navigation.resource, navigation.where);
+			return navigation.resource;
+		} else {
+			throw new SyntaxError(
+				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
+			);
 		}
 	}
 	AddNavigation(
@@ -1744,62 +1774,6 @@ export class OData2AbstractSQL {
 				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
 			);
 		}
-	}
-	AddJoins(
-		query: Query,
-		parentResource: Resource,
-		match:
-			| GenericPropertyPath<PropertyPath>
-			| Array<GenericPropertyPath<PropertyPath>>,
-		joinType: JoinType,
-	) {
-		if (Array.isArray(match)) {
-			match.forEach((v) => {
-				this.AddJoins(query, parentResource, v, joinType);
-			});
-		} else {
-			let nextProp = match;
-			let prop;
-			while (
-				// tslint:disable-next-line:no-conditional-assignment
-				(prop = nextProp) &&
-				prop.name &&
-				prop.property?.name
-			) {
-				nextProp = prop.property;
-				const resourceAlias = this.resourceAliases[prop.name];
-				if (resourceAlias) {
-					parentResource = resourceAlias;
-				} else {
-					parentResource = this.AddJoinNavigation(
-						query,
-						parentResource,
-						prop.name,
-						joinType,
-					);
-				}
-			}
-		}
-	}
-	AddJoinNavigation(
-		query: Query,
-		resource: Resource,
-		extraResource: string,
-		joinType: JoinType,
-	): AliasedResource {
-		const navigation = this.NavigateResources(resource, extraResource);
-		if (
-			!query.joins.some((join) => {
-				const from = join[1];
-				return (
-					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
-					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
-				);
-			})
-		) {
-			query.joinResource(this, navigation.resource, joinType, navigation.where);
-		}
-		return navigation.resource;
 	}
 
 	reset() {

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -73,6 +73,7 @@ import type {
 	UnknownTypeNodes,
 	FromTypeNode,
 	EqualsAnyNode,
+	JoinTypeNodes,
 } from '@balena/abstract-sql-compiler';
 import type {
 	ODataBinds,
@@ -84,10 +85,14 @@ import type {
 	OrderByPropertyPath,
 	FilterOption,
 	BindReference,
+	GenericPropertyPath,
+	PropertyPath,
 } from '@balena/odata-parser';
 export type { ODataBinds, ODataQuery, SupportedMethod };
 
 type InternalSupportedMethod = Exclude<SupportedMethod, 'MERGE'> | 'PUT-INSERT';
+
+type JoinType = 'Join' | 'LeftJoin' | 'RightJoin';
 
 type RequiredAbstractSqlModelSubset = Pick<
 	AbstractSqlModel,
@@ -220,6 +225,7 @@ class Query {
 	> = [];
 	public from: Array<FromNode[1]> = [];
 	public where: Array<WhereNode[1]> = [];
+	public joins: JoinTypeNodes[] = [];
 	public extras: Array<
 		FieldsNode | ValuesNode | OrderByNode | LimitNode | OffsetNode
 	> = [];
@@ -228,6 +234,7 @@ class Query {
 		this.select = this.select.concat(otherQuery.select);
 		this.from = this.from.concat(otherQuery.from);
 		this.where = this.where.concat(otherQuery.where);
+		this.joins = this.joins.concat(otherQuery.joins);
 		this.extras = this.extras.concat(otherQuery.extras);
 	}
 	fromResource(
@@ -249,6 +256,28 @@ class Query {
 			isModifyOperation,
 		);
 		this.from.push(tableRef);
+	}
+	joinResource(
+		odataToAbstractSql: OData2AbstractSQL,
+		resource: AliasedResource,
+		type: JoinType,
+		condition: BooleanTypeNodes,
+		args: {
+			extraBindVars: ODataBinds;
+			bindVarsLength: number;
+		} = odataToAbstractSql,
+		bypassDefinition?: boolean,
+	): void {
+		const tableRef = odataToAbstractSql.getTableReference(
+			resource,
+			args.extraBindVars,
+			args.bindVarsLength,
+			bypassDefinition,
+			resource.tableAlias,
+			undefined,
+		);
+		const joinNode: JoinTypeNodes = [type, tableRef, ['On', condition]];
+		this.joins.push(joinNode);
 	}
 	addNestedFieldSelect(fieldName: string, fieldNameAlias: string): void {
 		if (this.from.length !== 1) {
@@ -272,6 +301,9 @@ class Query {
 		}
 		this.from.forEach((tableName) => {
 			compiled.push(['From', tableName] as AbstractSqlQuery);
+		});
+		this.joins.forEach((joinNode) => {
+			compiled.push(joinNode);
 		});
 		if (where.length > 0) {
 			if (where.length > 1) {
@@ -878,7 +910,7 @@ export class OData2AbstractSQL {
 		query.where.push(where);
 	}
 	OrderBy(orderby: OrderByOption, query: Query, resource: Resource) {
-		this.AddExtraFroms(query, resource, orderby.properties);
+		this.AddJoins(query, resource, orderby.properties, 'LeftJoin');
 		query.extras.push([
 			'OrderBy',
 			...this.OrderByProperties(orderby.properties),
@@ -1712,6 +1744,62 @@ export class OData2AbstractSQL {
 				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
 			);
 		}
+	}
+	AddJoins(
+		query: Query,
+		parentResource: Resource,
+		match:
+			| GenericPropertyPath<PropertyPath>
+			| Array<GenericPropertyPath<PropertyPath>>,
+		joinType: JoinType,
+	) {
+		if (Array.isArray(match)) {
+			match.forEach((v) => {
+				this.AddJoins(query, parentResource, v, joinType);
+			});
+		} else {
+			let nextProp = match;
+			let prop;
+			while (
+				// tslint:disable-next-line:no-conditional-assignment
+				(prop = nextProp) &&
+				prop.name &&
+				prop.property?.name
+			) {
+				nextProp = prop.property;
+				const resourceAlias = this.resourceAliases[prop.name];
+				if (resourceAlias) {
+					parentResource = resourceAlias;
+				} else {
+					parentResource = this.AddJoinNavigation(
+						query,
+						parentResource,
+						prop.name,
+						joinType,
+					);
+				}
+			}
+		}
+	}
+	AddJoinNavigation(
+		query: Query,
+		resource: Resource,
+		extraResource: string,
+		joinType: JoinType,
+	): AliasedResource {
+		const navigation = this.NavigateResources(resource, extraResource);
+		if (
+			!query.joins.some((join) => {
+				const from = join[1];
+				return (
+					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
+					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
+				);
+			})
+		) {
+			query.joinResource(this, navigation.resource, joinType, navigation.where);
+		}
+		return navigation.resource;
 	}
 
 	reset() {

--- a/test/chai-sql-types.d.ts
+++ b/test/chai-sql-types.d.ts
@@ -13,6 +13,10 @@ declare namespace Chai {
 			table: string | string[],
 			...tables: string[] | string[][]
 		) => Assertion;
+		leftJoin: (
+			join: [string | string[], any[]],
+			...joins: Array<[string | string[], any[]]>
+		) => Assertion;
 		where: (clause?: any[]) => Assertion;
 		orderby: (...clause: any[]) => Assertion;
 		limit: (clause: any[]) => Assertion;

--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -108,7 +108,6 @@ chai.use(function ($chai, utils) {
 		return this;
 	});
 	utils.addMethod(assertionPrototype, 'groupby', multiBodyClause('GroupBy'));
-	utils.addMethod(assertionPrototype, 'where', bodyClause('Where'));
 	utils.addMethod(assertionPrototype, 'limit', bodyClause('Limit'));
 	utils.addMethod(assertionPrototype, 'offset', bodyClause('Offset'));
 });

--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -48,6 +48,17 @@ chai.use(function ($chai, utils) {
 			);
 			return this;
 		};
+	const binaryClause = (bodyType) =>
+		function (...bodyClauses) {
+			const obj = utils.flag(this, 'object');
+			for (let i = 0; i < bodyClauses.length; i++) {
+				expect(obj).to.contain.something.that.deep.equals(
+					[bodyType, bodyClauses[i][0], bodyClauses[i][1]],
+					bodyType + ' - ' + i,
+				);
+			}
+			return this;
+		};
 
 	const select = (function () {
 		const bodySelect = bodyClause('Select');
@@ -76,6 +87,15 @@ chai.use(function ($chai, utils) {
 			return ['Alias', ['Table', v[0]], v[1]];
 		});
 		return fromClause.apply(this, bodyClauses);
+	});
+	const leftJoinClause = binaryClause('LeftJoin');
+	utils.addMethod(assertionPrototype, 'leftJoin', function (...bodyClauses) {
+		bodyClauses = bodyClauses.map(function ([v, condition]) {
+			const resource =
+				typeof v === 'string' ? ['Table', v] : ['Alias', ['Table', v[0]], v[1]];
+			return [resource, ['On', condition]];
+		});
+		return leftJoinClause.apply(this, bodyClauses);
 	});
 	utils.addMethod(assertionPrototype, 'where', bodyClause('Where'));
 	utils.addMethod(assertionPrototype, 'orderby', function (...bodyClauses) {

--- a/test/expand.js
+++ b/test/expand.js
@@ -469,12 +469,16 @@ test('/pilot?$expand=licence&$orderby=licence/name asc', function (result) {
 				agg,
 				..._.reject(pilotFields, { 2: 'licence' }),
 			])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(['ASC', ['ReferencedField', 'pilot.licence', 'name']]);
 	});
 });

--- a/test/expand.js
+++ b/test/expand.js
@@ -253,28 +253,30 @@ test('/pilot?$expand=licence($filter=is_of__pilot/id eq 1)', function (result) {
 		.find({ 0: 'SelectQuery' })
 		.tap((aggSelect) =>
 			aggSelect.splice(aggSelect.length - 1, 0, [
-				'From',
+				'LeftJoin',
 				['Alias', ['Table', 'pilot'], 'pilot.licence.is of-pilot'],
-			]),
-		)
-		.find({ 0: 'Where' })
-		.tap(function (aggWhere) {
-			const currentWhere = aggWhere.splice(1, Infinity);
-			return aggWhere.push(
 				[
-					'And',
+					'On',
 					[
 						'Equals',
 						['ReferencedField', 'pilot.licence', 'id'],
 						['ReferencedField', 'pilot.licence.is of-pilot', 'licence'],
 					],
-					[
-						'IsNotDistinctFrom',
-						['ReferencedField', 'pilot.licence.is of-pilot', 'id'],
-						['Bind', 0],
-					],
-				].concat(currentWhere),
-			);
+				],
+			]),
+		)
+		.find({ 0: 'Where' })
+		.tap(function (aggWhere) {
+			const currentWhere = aggWhere.splice(1, Infinity);
+			return aggWhere.push([
+				'And',
+				[
+					'IsNotDistinctFrom',
+					['ReferencedField', 'pilot.licence.is of-pilot', 'id'],
+					['Bind', 0],
+				],
+				...currentWhere,
+			]);
 		})
 		.value();
 	it('should select from pilot.*, licence.*', () => {

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -47,7 +47,7 @@ test('/pilot?$orderby=name asc', (result) => {
 	});
 });
 
-test.skip('/pilot?$orderby=p/name asc', (result) => {
+test('/pilot?$orderby=p/name asc', (result) => {
 	// TODO: This should fail
 	it('should order by name asc using a non-existing alias', () => {
 		expect(result)
@@ -307,12 +307,16 @@ test('/pilot?$select=name,licence/name&$orderby=name asc,licence/name desc', fun
 				operandToAbstractSQL('name'),
 				operandToAbstractSQL('licence/name'),
 			])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(
 				['ASC', operandToAbstractSQL('name')],
 				['DESC', operandToAbstractSQL('licence/name')],

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -47,7 +47,7 @@ test('/pilot?$orderby=name asc', (result) => {
 	});
 });
 
-test('/pilot?$orderby=p/name asc', (result) => {
+test.skip('/pilot?$orderby=p/name asc', (result) => {
 	// TODO: This should fail
 	it('should order by name asc using a non-existing alias', () => {
 		expect(result)
@@ -73,12 +73,16 @@ test('/pilot?$orderby=licence/id asc', (result) => {
 	it('should order by licence/id asc', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(['ASC', operandToAbstractSQL('licence/id')]);
 	});
 });
@@ -87,12 +91,16 @@ test('/pilot?$orderby=licence/name asc,licence/id desc', (result) => {
 	it('should order by licence/name asc, licence/id desc w/o JOINing the licence twice', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(
 				['ASC', operandToAbstractSQL('licence/name')],
 				['DESC', operandToAbstractSQL('licence/id')],
@@ -104,24 +112,25 @@ test('/pilot?$orderby=can_fly__plane/plane/id asc', (result) => {
 	it('should order by can_fly__plane/plane/id asc', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			])
 			.orderby(['ASC', operandToAbstractSQL('can_fly__plane/plane/id')]);
 	});
 });
@@ -130,24 +139,26 @@ test('/pilot?$orderby=can_fly__plane/plane/name desc,can_fly__plane/plane/id asc
 	it('should order by can_fly__plane/plane/name desc, can_fly__plane/plane/id asc w/o JOINing the resources twice', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			])
+			.where()
 			.orderby(
 				['DESC', operandToAbstractSQL('can_fly__plane/plane/name')],
 				['ASC', operandToAbstractSQL('can_fly__plane/plane/id')],

--- a/test/select.js
+++ b/test/select.js
@@ -70,12 +70,16 @@ test('/pilot?$select=was_trained_by__pilot/name', (result) => {
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'was trained by'),
 			)
-			.from('pilot', ['pilot', 'pilot.was trained by-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'was trained by-pilot'],
-				['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.was trained by-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'was trained by-pilot'],
+					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -98,12 +102,16 @@ test('/pilot?$select=was_trained_by__pilot/p/name', (result) => {
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'was trained by'),
 			)
-			.from('pilot', ['pilot', 'pilot.was trained by-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'was trained by-pilot'],
-				['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.was trained by-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'was trained by-pilot'],
+					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -122,12 +130,16 @@ test('/pilot?$select=trained__pilot/name', (result) => {
 	it('should select name from pilot', () => {
 		expect(result)
 			.to.be.a.query.that.selects(aliasFields('pilot', [pilotName], 'trained'))
-			.from('pilot', ['pilot', 'pilot.trained-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'id'],
-				['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.trained-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'id'],
+					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -139,24 +151,26 @@ test('/pilot?$select=was_trained_by__pilot/name,trained__pilot/name', (result) =
 					aliasFields('pilot', [pilotName], 'trained'),
 				),
 			)
-			.from(
-				'pilot',
-				['pilot', 'pilot.was trained by-pilot'],
-				['pilot', 'pilot.trained-pilot'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot', 'pilot.was trained by-pilot'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'was trained by-pilot'],
+						['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+					],
+				],
+				[
+					['pilot', 'pilot.trained-pilot'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'was trained by-pilot'],
-					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-				],
-			]);
+			.where();
 	});
 });
 
@@ -166,12 +180,16 @@ test('/pilot?$select=trained__pilot/name,age', (result) => {
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'trained').concat([pilotAge]),
 			)
-			.from('pilot', ['pilot', 'pilot.trained-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'id'],
-				['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.trained-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'id'],
+					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -185,12 +203,16 @@ test('/pilot?$select=licence/id', (result) => {
 	it('should select licence/id for pilots', () => {
 		expect(result)
 			.to.be.a.query.that.selects([operandToAbstractSQL('licence/id')])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -200,24 +222,26 @@ test('/pilot?$select=can_fly__plane/plane/id', (result) => {
 			.to.be.a.query.that.selects([
 				operandToAbstractSQL('can_fly__plane/plane/id'),
 			])
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			]);
+			.where();
 	});
 });
 


### PR DESCRIPTION
Change-type: minor

Currently, the ORDER BY operation applies a FROM clause when dealing with nested resources, effectively performing an implicit JOIN. This approach inadvertently filters out any results that contain missing values, as they do not meet the join criteria. As a result, valid entries with null values in the ordered field are excluded from the final output.

To address this issue, this PR introduces a LEFT JOIN method instead. By using a LEFT JOIN, we ensure that all results are preserved, including those with null values, allowing for a more complete and accurate dataset when ordering is applied.

https://balena.fibery.io/Work/Project/Fix-removal-of-rows-with-null-values-when-sorting-by-an-associated-resource-984


Example:

```
await api.resin.get({
  resource: 'device',
  options: {
	  $select: ['id'],
	  $expand: {
		  is_running__release: {
			  $select: ['id', 'raw_version'],
		  },
	  },
	  $orderby: [
		  'is_running__release/semver_major asc',
		  'is_running__release/semver_minor asc',
		  'is_running__release/semver_patch asc',
		  'is_running__release/semver_prerelease asc',
		  'is_running__release/created_at asc',
		  'is_running__release/semver_build asc',
		  'is_running__release/revision asc',
		  'is_running__release/variant asc',
		  'belongs_to__application/app_name asc',
		  'id asc',
	  ],
  },
 });
```

generated query:

[LEFT_JOIN_EXAMPLE.txt](https://github.com/user-attachments/files/18825959/LEFT_JOIN_EXAMPLE.txt)
