### PR TITLE
Left join orderby reverse navigation resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BSD",
   "dependencies": {
     "@balena/abstract-sql-compiler": "^10.2.0",
-    "@balena/odata-parser": "^4.1.0",
+    "@balena/odata-parser": "^4.2.1",
     "@types/lodash": "^4.17.10",
     "@types/memoizee": "^0.4.11",
     "@types/string-hash": "^1.1.3",

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -85,11 +85,13 @@ import type {
 	OrderByPropertyPath,
 	FilterOption,
 	BindReference,
-	GenericPropertyPath,
 	PropertyPath,
 	MethodCall,
 } from '@balena/odata-parser';
 export type { ODataBinds, ODataQuery, SupportedMethod };
+
+// TODO: Remove this custom error once AddJoins stops silencing errors.
+class KeySyntaxError extends SyntaxError {}
 
 type InternalSupportedMethod = Exclude<SupportedMethod, 'MERGE'> | 'PUT-INSERT';
 
@@ -858,56 +860,85 @@ export class OData2AbstractSQL {
 					}
 				}
 			}
-			if (isBindReference(key)) {
-				const bind = this.Bind(key);
-				const referencedField: ReferencedFieldNode = [
-					'ReferencedField',
-					resource.tableAlias,
-					resource.idField,
-				];
-				return [comparison.eq, referencedField, bind];
-			}
-			const fieldNames = Object.keys(key);
-			const sqlFieldNames = fieldNames.map(odataNameToSqlName).sort();
-
-			const fields = sqlFieldNames.map((fieldName) => {
-				const resourceField = resource.fields.find(
-					(f) => f.fieldName === fieldName,
-				);
-				if (resourceField == null) {
-					throw new SyntaxError('Specified non-existent field for path key');
-				}
-				return resourceField;
-			});
-			if (
-				!(
-					fields.length === 1 &&
-					(fields[0].index === 'UNIQUE' || fields[0].index === 'PRIMARY KEY')
-				) &&
-				!resource.indexes.some((index) => {
-					return (
-						((index.type === 'UNIQUE' && index.predicate == null) ||
-							index.type === 'PRIMARY KEY') &&
-						sqlFieldNames.length === index.fields.length &&
-						_.isEqual(index.fields.slice().sort(), sqlFieldNames)
-					);
-				})
-			) {
-				throw new SyntaxError(
-					'Specified fields for path key that are not directly unique',
-				);
-			}
-
-			const namedKeys = fieldNames.map((fieldName): BooleanTypeNodes => {
-				const bind = this.Bind(key[fieldName]);
-				const referencedField = this.ReferencedField(resource, fieldName);
-				return [comparison.eq, referencedField, bind];
-			});
-			if (namedKeys.length === 1) {
-				return namedKeys[0];
-			}
-			return ['And', ...namedKeys];
+			return this.BaseKey(resource, key);
 		}
+	}
+	BaseKey(
+		resource: AliasedResource,
+		key: NonNullable<ODataQuery['key']>,
+		followedForeignKey?: string,
+	): BooleanTypeNodes {
+		if (isBindReference(key)) {
+			if (followedForeignKey != null) {
+				// We should be able to allow this if needed after v gets merged.
+				// https://github.com/balena-io-modules/odata-to-abstract-sql/pull/160
+				throw new KeySyntaxError(
+					'Using a key bind after a navigation expression is not supported.',
+				);
+			}
+			const bind = this.Bind(key);
+			const referencedField: ReferencedFieldNode = [
+				'ReferencedField',
+				resource.tableAlias,
+				resource.idField,
+			];
+			return [comparison.eq, referencedField, bind];
+		}
+		const fieldNames = Object.keys(key);
+		const sqlFieldNames = fieldNames.map(odataNameToSqlName);
+		if (followedForeignKey != null) {
+			if (sqlFieldNames.includes(followedForeignKey)) {
+				// Block providing FKs that we already navigated in an alternate key,
+				// since this would work like an additional filter.
+				throw new SyntaxError(
+					`Specified already navigated field as part of key: ${followedForeignKey}`,
+				);
+			}
+			// When following a FK, we check the whether the FK + the fields in the alternate notation
+			// complete a unique index. This allows users to not include the navigated FK property in
+			// the provided alternate key notation and define just the rest fields of the unique index.
+			// We effectively consider a navigated FK as implicitly defined in the alternate key notation.
+			sqlFieldNames.push(followedForeignKey);
+		}
+		sqlFieldNames.sort();
+
+		const fields = sqlFieldNames.map((fieldName) => {
+			const resourceField = resource.fields.find(
+				(f) => f.fieldName === fieldName,
+			);
+			if (resourceField == null) {
+				throw new SyntaxError('Specified non-existent field for path key');
+			}
+			return resourceField;
+		});
+		if (
+			!(
+				fields.length === 1 &&
+				(fields[0].index === 'UNIQUE' || fields[0].index === 'PRIMARY KEY')
+			) &&
+			!resource.indexes.some((index) => {
+				return (
+					((index.type === 'UNIQUE' && index.predicate == null) ||
+						index.type === 'PRIMARY KEY') &&
+					sqlFieldNames.length === index.fields.length &&
+					_.isEqual(index.fields.slice().sort(), sqlFieldNames)
+				);
+			})
+		) {
+			throw new KeySyntaxError(
+				'Specified fields for path key that are not directly unique',
+			);
+		}
+
+		const namedKeys = fieldNames.map((fieldName): BooleanTypeNodes => {
+			const bind = this.Bind(key[fieldName]);
+			const referencedField = this.ReferencedField(resource, fieldName);
+			return [comparison.eq, referencedField, bind];
+		});
+		if (namedKeys.length === 1) {
+			return namedKeys[0];
+		}
+		return ['And', ...namedKeys];
 	}
 	Bind(bind: BindReference, optional: true): BindNode | undefined;
 	Bind(bind: BindReference): BindNode;
@@ -1689,13 +1720,19 @@ export class OData2AbstractSQL {
 	NavigateResources(
 		resource: Resource,
 		navigation: string,
-	): { resource: AliasedResource; where: BooleanTypeNodes } {
+	): {
+		resource: AliasedResource;
+		navigationResourceField: string;
+		where: BooleanTypeNodes;
+	} {
 		const relationshipMapping = this.ResolveRelationship(resource, navigation);
 		const linkedResource = this.Resource(navigation, resource);
 		const tableAlias = resource.tableAlias ?? resource.name;
 		const linkedTableAlias = linkedResource.tableAlias ?? linkedResource.name;
 		return {
 			resource: linkedResource,
+			// Include the FK used, to re-use it in any follow-up alternate Key check.
+			navigationResourceField: relationshipMapping[1][1],
 			where: [
 				'Equals',
 				['ReferencedField', tableAlias, relationshipMapping[0]],
@@ -1707,9 +1744,7 @@ export class OData2AbstractSQL {
 		query: Query,
 		parentResource: Resource,
 		// This can be any node that odata-parser returns
-		match:
-			| (GenericPropertyPath<PropertyPath> | MethodCall[1])
-			| Array<GenericPropertyPath<PropertyPath> | MethodCall[1]>,
+		match: (PropertyPath | MethodCall[1]) | Array<PropertyPath | MethodCall[1]>,
 	) {
 		// TODO: try removing
 		try {
@@ -1737,6 +1772,7 @@ export class OData2AbstractSQL {
 							query,
 							parentResource,
 							prop.name,
+							prop.key,
 						);
 					}
 				}
@@ -1744,7 +1780,10 @@ export class OData2AbstractSQL {
 					this.AddJoins(query, parentResource, nextProp.args);
 				}
 			}
-		} catch {
+		} catch (e) {
+			if (e instanceof KeySyntaxError) {
+				throw e;
+			}
 			// ignore
 		}
 	}
@@ -1752,24 +1791,66 @@ export class OData2AbstractSQL {
 		query: Query,
 		resource: Resource,
 		extraResource: string,
+		key?: ODataQuery['key'],
 	): AliasedResource {
 		const navigation = this.NavigateResources(resource, extraResource);
-		if (
-			!query.joins.some((join) => {
-				const from = join[1];
-				return (
-					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
-					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
+		if (key != null) {
+			try {
+				const keyWhere = this.BaseKey(
+					navigation.resource,
+					key,
+					navigation.navigationResourceField,
 				);
-			})
-		) {
-			query.joinResource(this, navigation.resource, navigation.where);
-			return navigation.resource;
-		} else {
+				navigation.where = ['And', navigation.where, keyWhere];
+			} catch (e) {
+				if (e instanceof SyntaxError) {
+					// Since there is a TODO in the AddJoins to stop silencing errors, instead of
+					// silencing the new Syntax errors that can be thrown by the added BaseKey().
+					// we decided use a new custom error to detect those new errors and re-throw them.
+					throw new KeySyntaxError(e.message, { cause: e });
+				}
+				throw e;
+			}
+		}
+		const existingJoin = query.joins.find((join) => {
+			const existingFrom = join[1];
+			return (
+				(isTableNode(existingFrom) &&
+					existingFrom[1] === navigation.resource.tableAlias) ||
+				(isAliasNode(existingFrom) &&
+					existingFrom[2] === navigation.resource.tableAlias)
+			);
+		});
+		if (existingJoin != null) {
+			const existingJoinPredicate = existingJoin[2]?.[1];
+			// When a key is used, the predicae has an And node.
+			const isJoinWithoutKey = existingJoinPredicate?.[0] === 'Equals';
+
+			// This is pretty much equivalent to _.isEqual(navigation.where, existingJoinPredicate),
+			// but it tries to avoid the cost of isEqual by checking some simpler conditions first.
+			const isSamePredicateJoin =
+				// When JOINing resources w/o any additional key, the ON clauses will be equal as long as the aliases are the same.
+				(key == null && isJoinWithoutKey) ||
+				// We only need to run isEqual if both queries are using a key, otherwise we know upfront that the ONs are different.
+				(key != null &&
+					!isJoinWithoutKey &&
+					_.isEqual(navigation.where, existingJoinPredicate));
+			if (!isSamePredicateJoin) {
+				// When we reach this point we have found an already existing JOIN with the
+				// same alias as the one we just created but different ON predicate.
+				// TODO: In this case we need to be able to generate a new alias for the newly JOINed resource.
+				// Since we atm do not support that we throw early, since otherwise the generated query would be invalid.
+				throw new KeySyntaxError(
+					`Adding JOINs on the same resource with different ON clauses is not supported. Found ${navigation.resource.tableAlias}`,
+				);
+			}
+
 			throw new SyntaxError(
 				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
 			);
 		}
+		query.joinResource(this, navigation.resource, navigation.where);
+		return navigation.resource;
 	}
 	AddNavigation(
 		query: Query,

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -87,12 +87,11 @@ import type {
 	BindReference,
 	GenericPropertyPath,
 	PropertyPath,
+	MethodCall,
 } from '@balena/odata-parser';
 export type { ODataBinds, ODataQuery, SupportedMethod };
 
 type InternalSupportedMethod = Exclude<SupportedMethod, 'MERGE'> | 'PUT-INSERT';
-
-type JoinType = 'Join' | 'LeftJoin' | 'RightJoin';
 
 type RequiredAbstractSqlModelSubset = Pick<
 	AbstractSqlModel,
@@ -278,7 +277,6 @@ class Query {
 	joinResource(
 		odataToAbstractSql: OData2AbstractSQL,
 		resource: AliasedResource,
-		type: JoinType,
 		condition: BooleanTypeNodes,
 		args: {
 			extraBindVars: ODataBinds;
@@ -294,7 +292,7 @@ class Query {
 			resource.tableAlias,
 			undefined,
 		);
-		const joinNode: JoinTypeNodes = [type, tableRef, ['On', condition]];
+		const joinNode: JoinTypeNodes = ['LeftJoin', tableRef, ['On', condition]];
 		this.joins.push(joinNode);
 	}
 	addNestedFieldSelect(fieldName: string, fieldNameAlias: string): void {
@@ -923,12 +921,12 @@ export class OData2AbstractSQL {
 		throw new SyntaxError(`Could not match bind reference`);
 	}
 	SelectFilter(filter: FilterOption, query: Query, resource: Resource) {
-		this.AddExtraFroms(query, resource, filter);
+		this.AddJoins(query, resource, filter);
 		const where = this.BooleanMatch(filter);
 		query.where.push(where);
 	}
 	OrderBy(orderby: OrderByOption, query: Query, resource: Resource) {
-		this.AddJoins(query, resource, orderby.properties, 'LeftJoin');
+		this.AddJoins(query, resource, orderby.properties);
 		query.extras.push([
 			'OrderBy',
 			...this.OrderByProperties(orderby.properties),
@@ -1077,7 +1075,7 @@ export class OData2AbstractSQL {
 			Parameters<OData2AbstractSQL['AliasSelectField']>
 		>;
 		if (path.options?.$select?.properties) {
-			this.AddExtraFroms(query, resource, path.options.$select.properties);
+			this.AddJoins(query, resource, path.options.$select.properties);
 			odataFieldNames = path.options.$select.properties.map((prop: any) => {
 				const field = this.Property(prop) as {
 					resource: Resource;
@@ -1348,7 +1346,7 @@ export class OData2AbstractSQL {
 			this.resourceAliases[lambda.identifier] = resource;
 
 			this.defaultResource = resource;
-			this.AddExtraFroms(query, resource, lambda.expression);
+			this.AddJoins(query, resource, lambda.expression);
 			const filter = this.BooleanMatch(lambda.expression);
 			if (lambda.method === 'any') {
 				query.where.push(filter);
@@ -1705,12 +1703,19 @@ export class OData2AbstractSQL {
 			],
 		};
 	}
-	AddExtraFroms(query: Query, parentResource: Resource, match: any) {
+	AddJoins(
+		query: Query,
+		parentResource: Resource,
+		// This can be any node that odata-parser returns
+		match:
+			| (GenericPropertyPath<PropertyPath> | MethodCall[1])
+			| Array<GenericPropertyPath<PropertyPath> | MethodCall[1]>,
+	) {
 		// TODO: try removing
 		try {
 			if (Array.isArray(match)) {
 				match.forEach((v) => {
-					this.AddExtraFroms(query, parentResource, v);
+					this.AddJoins(query, parentResource, v);
 				});
 			} else {
 				let nextProp = match;
@@ -1718,6 +1723,8 @@ export class OData2AbstractSQL {
 				while (
 					// tslint:disable-next-line:no-conditional-assignment
 					(prop = nextProp) &&
+					// Confirm that prop is indeed a GenericPropertyPath<PropertyPath>
+					'name' in prop &&
 					prop.name &&
 					prop.property?.name
 				) {
@@ -1726,19 +1733,42 @@ export class OData2AbstractSQL {
 					if (resourceAlias) {
 						parentResource = resourceAlias;
 					} else {
-						parentResource = this.AddNavigation(
+						parentResource = this.AddJoinNavigation(
 							query,
 							parentResource,
 							prop.name,
 						);
 					}
 				}
-				if (nextProp?.args) {
-					this.AddExtraFroms(query, parentResource, prop.args);
+				if (nextProp != null && 'args' in nextProp && nextProp.args != null) {
+					this.AddJoins(query, parentResource, nextProp.args);
 				}
 			}
 		} catch {
 			// ignore
+		}
+	}
+	AddJoinNavigation(
+		query: Query,
+		resource: Resource,
+		extraResource: string,
+	): AliasedResource {
+		const navigation = this.NavigateResources(resource, extraResource);
+		if (
+			!query.joins.some((join) => {
+				const from = join[1];
+				return (
+					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
+					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
+				);
+			})
+		) {
+			query.joinResource(this, navigation.resource, navigation.where);
+			return navigation.resource;
+		} else {
+			throw new SyntaxError(
+				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
+			);
 		}
 	}
 	AddNavigation(
@@ -1762,62 +1792,6 @@ export class OData2AbstractSQL {
 				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
 			);
 		}
-	}
-	AddJoins(
-		query: Query,
-		parentResource: Resource,
-		match:
-			| GenericPropertyPath<PropertyPath>
-			| Array<GenericPropertyPath<PropertyPath>>,
-		joinType: JoinType,
-	) {
-		if (Array.isArray(match)) {
-			match.forEach((v) => {
-				this.AddJoins(query, parentResource, v, joinType);
-			});
-		} else {
-			let nextProp = match;
-			let prop;
-			while (
-				// tslint:disable-next-line:no-conditional-assignment
-				(prop = nextProp) &&
-				prop.name &&
-				prop.property?.name
-			) {
-				nextProp = prop.property;
-				const resourceAlias = this.resourceAliases[prop.name];
-				if (resourceAlias) {
-					parentResource = resourceAlias;
-				} else {
-					parentResource = this.AddJoinNavigation(
-						query,
-						parentResource,
-						prop.name,
-						joinType,
-					);
-				}
-			}
-		}
-	}
-	AddJoinNavigation(
-		query: Query,
-		resource: Resource,
-		extraResource: string,
-		joinType: JoinType,
-	): AliasedResource {
-		const navigation = this.NavigateResources(resource, extraResource);
-		if (
-			!query.joins.some((join) => {
-				const from = join[1];
-				return (
-					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
-					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
-				);
-			})
-		) {
-			query.joinResource(this, navigation.resource, joinType, navigation.where);
-		}
-		return navigation.resource;
 	}
 
 	reset() {

--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -73,6 +73,7 @@ import type {
 	UnknownTypeNodes,
 	FromTypeNode,
 	EqualsAnyNode,
+	JoinTypeNodes,
 } from '@balena/abstract-sql-compiler';
 import type {
 	ODataBinds,
@@ -84,10 +85,14 @@ import type {
 	OrderByPropertyPath,
 	FilterOption,
 	BindReference,
+	GenericPropertyPath,
+	PropertyPath,
 } from '@balena/odata-parser';
 export type { ODataBinds, ODataQuery, SupportedMethod };
 
 type InternalSupportedMethod = Exclude<SupportedMethod, 'MERGE'> | 'PUT-INSERT';
+
+type JoinType = 'Join' | 'LeftJoin' | 'RightJoin';
 
 type RequiredAbstractSqlModelSubset = Pick<
 	AbstractSqlModel,
@@ -238,6 +243,7 @@ class Query {
 	> = [];
 	public from: Array<FromNode[1]> = [];
 	public where: Array<WhereNode[1]> = [];
+	public joins: JoinTypeNodes[] = [];
 	public extras: Array<
 		FieldsNode | ValuesNode | OrderByNode | LimitNode | OffsetNode
 	> = [];
@@ -246,6 +252,7 @@ class Query {
 		this.select = this.select.concat(otherQuery.select);
 		this.from = this.from.concat(otherQuery.from);
 		this.where = this.where.concat(otherQuery.where);
+		this.joins = this.joins.concat(otherQuery.joins);
 		this.extras = this.extras.concat(otherQuery.extras);
 	}
 	fromResource(
@@ -267,6 +274,28 @@ class Query {
 			isModifyOperation,
 		);
 		this.from.push(tableRef);
+	}
+	joinResource(
+		odataToAbstractSql: OData2AbstractSQL,
+		resource: AliasedResource,
+		type: JoinType,
+		condition: BooleanTypeNodes,
+		args: {
+			extraBindVars: ODataBinds;
+			bindVarsLength: number;
+		} = odataToAbstractSql,
+		bypassDefinition?: boolean,
+	): void {
+		const tableRef = odataToAbstractSql.getTableReference(
+			resource,
+			args.extraBindVars,
+			args.bindVarsLength,
+			bypassDefinition,
+			resource.tableAlias,
+			undefined,
+		);
+		const joinNode: JoinTypeNodes = [type, tableRef, ['On', condition]];
+		this.joins.push(joinNode);
 	}
 	addNestedFieldSelect(fieldName: string, fieldNameAlias: string): void {
 		if (this.from.length !== 1) {
@@ -290,6 +319,9 @@ class Query {
 		}
 		this.from.forEach((tableName) => {
 			compiled.push(['From', tableName] as AbstractSqlQuery);
+		});
+		this.joins.forEach((joinNode) => {
+			compiled.push(joinNode);
 		});
 		if (where.length > 0) {
 			if (where.length > 1) {
@@ -896,7 +928,7 @@ export class OData2AbstractSQL {
 		query.where.push(where);
 	}
 	OrderBy(orderby: OrderByOption, query: Query, resource: Resource) {
-		this.AddExtraFroms(query, resource, orderby.properties);
+		this.AddJoins(query, resource, orderby.properties, 'LeftJoin');
 		query.extras.push([
 			'OrderBy',
 			...this.OrderByProperties(orderby.properties),
@@ -1730,6 +1762,62 @@ export class OData2AbstractSQL {
 				`Could not navigate resources '${resource.name}' and '${extraResource}'`,
 			);
 		}
+	}
+	AddJoins(
+		query: Query,
+		parentResource: Resource,
+		match:
+			| GenericPropertyPath<PropertyPath>
+			| Array<GenericPropertyPath<PropertyPath>>,
+		joinType: JoinType,
+	) {
+		if (Array.isArray(match)) {
+			match.forEach((v) => {
+				this.AddJoins(query, parentResource, v, joinType);
+			});
+		} else {
+			let nextProp = match;
+			let prop;
+			while (
+				// tslint:disable-next-line:no-conditional-assignment
+				(prop = nextProp) &&
+				prop.name &&
+				prop.property?.name
+			) {
+				nextProp = prop.property;
+				const resourceAlias = this.resourceAliases[prop.name];
+				if (resourceAlias) {
+					parentResource = resourceAlias;
+				} else {
+					parentResource = this.AddJoinNavigation(
+						query,
+						parentResource,
+						prop.name,
+						joinType,
+					);
+				}
+			}
+		}
+	}
+	AddJoinNavigation(
+		query: Query,
+		resource: Resource,
+		extraResource: string,
+		joinType: JoinType,
+	): AliasedResource {
+		const navigation = this.NavigateResources(resource, extraResource);
+		if (
+			!query.joins.some((join) => {
+				const from = join[1];
+				return (
+					(isTableNode(from) && from[1] === navigation.resource.tableAlias) ||
+					(isAliasNode(from) && from[2] === navigation.resource.tableAlias)
+				);
+			})
+		) {
+			query.joinResource(this, navigation.resource, joinType, navigation.where);
+		}
+		return navigation.resource;
 	}
 
 	reset() {

--- a/test/chai-sql-types.d.ts
+++ b/test/chai-sql-types.d.ts
@@ -13,6 +13,10 @@ declare namespace Chai {
 			table: string | string[],
 			...tables: string[] | string[][]
 		) => Assertion;
+		leftJoin: (
+			join: [string | string[], any[]],
+			...joins: Array<[string | string[], any[]]>
+		) => Assertion;
 		where: (clause?: any[]) => Assertion;
 		orderby: (...clause: any[]) => Assertion;
 		limit: (clause: any[]) => Assertion;

--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -108,7 +108,6 @@ chai.use(function ($chai, utils) {
 		return this;
 	});
 	utils.addMethod(assertionPrototype, 'groupby', multiBodyClause('GroupBy'));
-	utils.addMethod(assertionPrototype, 'where', bodyClause('Where'));
 	utils.addMethod(assertionPrototype, 'limit', bodyClause('Limit'));
 	utils.addMethod(assertionPrototype, 'offset', bodyClause('Offset'));
 });

--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -48,6 +48,17 @@ chai.use(function ($chai, utils) {
 			);
 			return this;
 		};
+	const binaryClause = (bodyType) =>
+		function (...bodyClauses) {
+			const obj = utils.flag(this, 'object');
+			for (let i = 0; i < bodyClauses.length; i++) {
+				expect(obj).to.contain.something.that.deep.equals(
+					[bodyType, bodyClauses[i][0], bodyClauses[i][1]],
+					bodyType + ' - ' + i,
+				);
+			}
+			return this;
+		};
 
 	const select = (function () {
 		const bodySelect = bodyClause('Select');
@@ -76,6 +87,15 @@ chai.use(function ($chai, utils) {
 			return ['Alias', ['Table', v[0]], v[1]];
 		});
 		return fromClause.apply(this, bodyClauses);
+	});
+	const leftJoinClause = binaryClause('LeftJoin');
+	utils.addMethod(assertionPrototype, 'leftJoin', function (...bodyClauses) {
+		bodyClauses = bodyClauses.map(function ([v, condition]) {
+			const resource =
+				typeof v === 'string' ? ['Table', v] : ['Alias', ['Table', v[0]], v[1]];
+			return [resource, ['On', condition]];
+		});
+		return leftJoinClause.apply(this, bodyClauses);
 	});
 	utils.addMethod(assertionPrototype, 'where', bodyClause('Where'));
 	utils.addMethod(assertionPrototype, 'orderby', function (...bodyClauses) {

--- a/test/expand.js
+++ b/test/expand.js
@@ -469,12 +469,16 @@ test('/pilot?$expand=licence&$orderby=licence/name asc', function (result) {
 				agg,
 				..._.reject(pilotFields, { 2: 'licence' }),
 			])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(['ASC', ['ReferencedField', 'pilot.licence', 'name']]);
 	});
 });

--- a/test/expand.js
+++ b/test/expand.js
@@ -253,28 +253,30 @@ test('/pilot?$expand=licence($filter=is_of__pilot/id eq 1)', function (result) {
 		.find({ 0: 'SelectQuery' })
 		.tap((aggSelect) =>
 			aggSelect.splice(aggSelect.length - 1, 0, [
-				'From',
+				'LeftJoin',
 				['Alias', ['Table', 'pilot'], 'pilot.licence.is of-pilot'],
-			]),
-		)
-		.find({ 0: 'Where' })
-		.tap(function (aggWhere) {
-			const currentWhere = aggWhere.splice(1, Infinity);
-			return aggWhere.push(
 				[
-					'And',
+					'On',
 					[
 						'Equals',
 						['ReferencedField', 'pilot.licence', 'id'],
 						['ReferencedField', 'pilot.licence.is of-pilot', 'licence'],
 					],
-					[
-						'IsNotDistinctFrom',
-						['ReferencedField', 'pilot.licence.is of-pilot', 'id'],
-						['Bind', 0],
-					],
-				].concat(currentWhere),
-			);
+				],
+			]),
+		)
+		.find({ 0: 'Where' })
+		.tap(function (aggWhere) {
+			const currentWhere = aggWhere.splice(1, Infinity);
+			return aggWhere.push([
+				'And',
+				[
+					'IsNotDistinctFrom',
+					['ReferencedField', 'pilot.licence.is of-pilot', 'id'],
+					['Bind', 0],
+				],
+				...currentWhere,
+			]);
 		})
 		.value();
 	it('should select from pilot.*, licence.*', () => {

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -47,7 +47,7 @@ test('/pilot?$orderby=name asc', (result) => {
 	});
 });
 
-test.skip('/pilot?$orderby=p/name asc', (result) => {
+test('/pilot?$orderby=p/name asc', (result) => {
 	// TODO: This should fail
 	it('should order by name asc using a non-existing alias', () => {
 		expect(result)
@@ -307,12 +307,16 @@ test('/pilot?$select=name,licence/name&$orderby=name asc,licence/name desc', fun
 				operandToAbstractSQL('name'),
 				operandToAbstractSQL('licence/name'),
 			])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(
 				['ASC', operandToAbstractSQL('name')],
 				['DESC', operandToAbstractSQL('licence/name')],

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -47,7 +47,7 @@ test('/pilot?$orderby=name asc', (result) => {
 	});
 });
 
-test('/pilot?$orderby=p/name asc', (result) => {
+test.skip('/pilot?$orderby=p/name asc', (result) => {
 	// TODO: This should fail
 	it('should order by name asc using a non-existing alias', () => {
 		expect(result)
@@ -73,12 +73,16 @@ test('/pilot?$orderby=licence/id asc', (result) => {
 	it('should order by licence/id asc', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(['ASC', operandToAbstractSQL('licence/id')]);
 	});
 });
@@ -87,12 +91,16 @@ test('/pilot?$orderby=licence/name asc,licence/id desc', (result) => {
 	it('should order by licence/name asc, licence/id desc w/o JOINing the licence twice', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
+			.where()
 			.orderby(
 				['ASC', operandToAbstractSQL('licence/name')],
 				['DESC', operandToAbstractSQL('licence/id')],
@@ -104,24 +112,25 @@ test('/pilot?$orderby=can_fly__plane/plane/id asc', (result) => {
 	it('should order by can_fly__plane/plane/id asc', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			])
 			.orderby(['ASC', operandToAbstractSQL('can_fly__plane/plane/id')]);
 	});
 });
@@ -130,24 +139,26 @@ test('/pilot?$orderby=can_fly__plane/plane/name desc,can_fly__plane/plane/id asc
 	it('should order by can_fly__plane/plane/name desc, can_fly__plane/plane/id asc w/o JOINing the resources twice', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			])
+			.where()
 			.orderby(
 				['DESC', operandToAbstractSQL('can_fly__plane/plane/name')],
 				['ASC', operandToAbstractSQL('can_fly__plane/plane/id')],

--- a/test/select.js
+++ b/test/select.js
@@ -70,12 +70,16 @@ test('/pilot?$select=was_trained_by__pilot/name', (result) => {
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'was trained by'),
 			)
-			.from('pilot', ['pilot', 'pilot.was trained by-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'was trained by-pilot'],
-				['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.was trained by-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'was trained by-pilot'],
+					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -98,12 +102,16 @@ test('/pilot?$select=was_trained_by__pilot/p/name', (result) => {
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'was trained by'),
 			)
-			.from('pilot', ['pilot', 'pilot.was trained by-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'was trained by-pilot'],
-				['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.was trained by-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'was trained by-pilot'],
+					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -122,12 +130,16 @@ test('/pilot?$select=trained__pilot/name', (result) => {
 	it('should select name from pilot', () => {
 		expect(result)
 			.to.be.a.query.that.selects(aliasFields('pilot', [pilotName], 'trained'))
-			.from('pilot', ['pilot', 'pilot.trained-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'id'],
-				['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.trained-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'id'],
+					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -139,24 +151,26 @@ test('/pilot?$select=was_trained_by__pilot/name,trained__pilot/name', (result) =
 					aliasFields('pilot', [pilotName], 'trained'),
 				),
 			)
-			.from(
-				'pilot',
-				['pilot', 'pilot.was trained by-pilot'],
-				['pilot', 'pilot.trained-pilot'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot', 'pilot.was trained by-pilot'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'was trained by-pilot'],
+						['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+					],
+				],
+				[
+					['pilot', 'pilot.trained-pilot'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'was trained by-pilot'],
-					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-				],
-			]);
+			.where();
 	});
 });
 
@@ -166,12 +180,16 @@ test('/pilot?$select=trained__pilot/name,age', (result) => {
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'trained').concat([pilotAge]),
 			)
-			.from('pilot', ['pilot', 'pilot.trained-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'id'],
-				['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.trained-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'id'],
+					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -185,12 +203,16 @@ test('/pilot?$select=licence/id', (result) => {
 	it('should select licence/id for pilots', () => {
 		expect(result)
 			.to.be.a.query.that.selects([operandToAbstractSQL('licence/id')])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
-			]);
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
+			])
+			.where();
 	});
 });
 
@@ -200,24 +222,26 @@ test('/pilot?$select=can_fly__plane/plane/id', (result) => {
 			.to.be.a.query.that.selects([
 				operandToAbstractSQL('can_fly__plane/plane/id'),
 			])
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			]);
+			.where();
 	});
 });
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -66,3 +66,41 @@ test.skip = runExpectation.bind(null, describe.skip);
 test.only = runExpectation.bind(null, describe.only);
 
 export default test;
+
+export const itExpectsError = (
+	title: string,
+	fn: (this: Mocha.Context) => void,
+	expectedError: string | RegExp | ((err: Error) => boolean),
+) => {
+	it(`[Expect test case to fail] ${title}`, function () {
+		try {
+			fn?.call(this);
+			throw new Error(`
+				(Maybe a good one) Test case:
+				> ${title}
+
+				that was expected to fail, now completed without issues!
+				Confirm whether the test was properly fixed and change its 'itExpectsError()' to an 'it()'.
+				Thanks for fixing it!
+			`);
+		} catch (err) {
+			if (!(err instanceof Error)) {
+				throw err;
+			}
+			const isExpectedError =
+				typeof expectedError === 'function'
+					? expectedError
+					: (e: Error) => {
+							if (typeof expectedError === 'string') {
+								return expectedError === e.message;
+							}
+							if (expectedError instanceof RegExp) {
+								return expectedError.test(e.message);
+							}
+						};
+			if (!isExpectedError(err)) {
+				throw err;
+			}
+		}
+	});
+};


### PR DESCRIPTION
On top of https://github.com/balena-io-modules/odata-to-abstract-sql/pull/160, so let's get that in first

Depends-on: https://github.com/balena-io-modules/odata-parser/pull/96
Depends-on: https://github.com/balena-io-modules/odata-parser/pull/98
Change-type: minor
See: https://github.com/balena-io/pinejs/issues/824
See: https://balena.fibery.io/Work/Project/Shape--Build-Add-support-for-sorting-on-user-selected-tag-columns-in-the-server-side-paginated-devic-912