### PR TITLE
Fix removing rows that have a NULL FK on any provided $select path

### DIFF
--- a/src/odata-to-abstract-sql.ts
+++ b/src/odata-to-abstract-sql.ts
@@ -1072,7 +1072,12 @@ export class OData2AbstractSQL {
 			Parameters<OData2AbstractSQL['AliasSelectField']>
 		>;
 		if (path.options?.$select?.properties) {
-			this.AddExtraFroms(query, resource, path.options.$select.properties);
+			this.AddJoins(
+				query,
+				resource,
+				path.options.$select.properties,
+				'LeftJoin',
+			);
 			odataFieldNames = path.options.$select.properties.map((prop: any) => {
 				const field = this.Property(prop) as {
 					resource: Resource;

--- a/test/chai-sql-types.d.ts
+++ b/test/chai-sql-types.d.ts
@@ -17,7 +17,7 @@ declare namespace Chai {
 			join: [string | string[], any[]],
 			...joins: Array<[string | string[], any[]]>
 		) => Assertion;
-		where: (clause: any[]) => Assertion;
+		where: (clause?: any[]) => Assertion;
 		orderby: (...clause: any[]) => Assertion;
 		limit: (clause: any[]) => Assertion;
 		offset: (clause: any[]) => Assertion;

--- a/test/chai-sql-types.d.ts
+++ b/test/chai-sql-types.d.ts
@@ -13,6 +13,10 @@ declare namespace Chai {
 			table: string | string[],
 			...tables: string[] | string[][]
 		) => Assertion;
+		leftJoin: (
+			join: [string | string[], any[]],
+			...joins: Array<[string | string[], any[]]>
+		) => Assertion;
 		where: (clause: any[]) => Assertion;
 		orderby: (...clause: any[]) => Assertion;
 		limit: (clause: any[]) => Assertion;

--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -40,6 +40,17 @@ chai.use(function ($chai, utils) {
 			);
 			return this;
 		};
+	const binaryClause = (bodyType) =>
+		function (...bodyClauses) {
+			const obj = utils.flag(this, 'object');
+			for (let i = 0; i < bodyClauses.length; i++) {
+				expect(obj).to.contain.something.that.deep.equals(
+					[bodyType, bodyClauses[i][0], bodyClauses[i][1]],
+					bodyType + ' - ' + i,
+				);
+			}
+			return this;
+		};
 
 	const select = (function () {
 		const bodySelect = bodyClause('Select');
@@ -68,6 +79,15 @@ chai.use(function ($chai, utils) {
 			return ['Alias', ['Table', v[0]], v[1]];
 		});
 		return fromClause.apply(this, bodyClauses);
+	});
+	const leftJoinClause = binaryClause('LeftJoin');
+	utils.addMethod(assertionPrototype, 'leftJoin', function (...bodyClauses) {
+		bodyClauses = bodyClauses.map(function ([v, condition]) {
+			const resource =
+				typeof v === 'string' ? ['Table', v] : ['Alias', ['Table', v[0]], v[1]];
+			return [resource, ['On', condition]];
+		});
+		return leftJoinClause.apply(this, bodyClauses);
 	});
 	utils.addMethod(assertionPrototype, 'where', bodyClause('Where'));
 	utils.addMethod(assertionPrototype, 'orderby', function (...bodyClauses) {

--- a/test/chai-sql.js
+++ b/test/chai-sql.js
@@ -23,11 +23,19 @@ chai.use(function ($chai, utils) {
 	const bodyClause = (bodyType) =>
 		function (...bodyClauses) {
 			const obj = utils.flag(this, 'object');
-			for (let i = 0; i < bodyClauses.length; i++) {
-				expect(obj).to.contain.something.that.deep.equals(
-					[bodyType, bodyClauses[i]],
-					bodyType + ' - ' + i,
+			if (bodyClauses.length === 0) {
+				const topLevelBodyTypeNodes = obj.filter(
+					(v) => Array.isArray(v) && v[0] === bodyType,
 				);
+				// We use deep.equal as an easy way to print the diff in case this fails
+				expect(topLevelBodyTypeNodes).to.deep.equal([]);
+			} else {
+				for (let i = 0; i < bodyClauses.length; i++) {
+					expect(obj).to.contain.something.that.deep.equals(
+						[bodyType, bodyClauses[i]],
+						bodyType + ' - ' + i,
+					);
+				}
 			}
 			return this;
 		};
@@ -100,7 +108,6 @@ chai.use(function ($chai, utils) {
 		return this;
 	});
 	utils.addMethod(assertionPrototype, 'groupby', multiBodyClause('GroupBy'));
-	utils.addMethod(assertionPrototype, 'where', bodyClause('Where'));
 	utils.addMethod(assertionPrototype, 'limit', bodyClause('Limit'));
 	utils.addMethod(assertionPrototype, 'offset', bodyClause('Offset'));
 });

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -50,40 +50,46 @@ test('/pilot?$orderby=name asc,age desc', (result) =>
 			)));
 
 test('/pilot?$orderby=licence/id asc', (result) =>
-	it('should order by licence/id asc', () =>
+	it('should order by licence/id asc', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
 			])
-			.orderby(['ASC', operandToAbstractSQL('licence/id')])));
+			.orderby(['ASC', operandToAbstractSQL('licence/id')]);
+	}));
 
 test('/pilot?$orderby=can_fly__plane/plane/id asc', (result) =>
-	it('should order by can_fly__plane/plane/id asc', () =>
+	it('should order by can_fly__plane/plane/id asc', () => {
 		expect(result)
 			.to.be.a.query.that.selects(pilotFields)
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			])
-			.orderby(['ASC', operandToAbstractSQL('can_fly__plane/plane/id')])));
+			.orderby(['ASC', operandToAbstractSQL('can_fly__plane/plane/id')]);
+	}));
 
 test.skip('/pilot?$orderby=favourite_colour/red', () =>
 	it("should order by how red the pilot's favourite colour is"));
@@ -215,5 +221,25 @@ test('/team?$orderby=includes__pilot/$count($filter=is_experienced eq true) desc
 					],
 				],
 			]);
+	});
+});
+
+test('/pilot?$orderby=licence/name asc,licence/id asc', (result) => {
+	it('should order pilot by licence/name asc and licence/id asc', () => {
+		expect(result)
+			.to.be.a.query.that.selects(pilotFields)
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
+			])
+			.orderby(
+				['ASC', operandToAbstractSQL('licence/name')],
+				['ASC', operandToAbstractSQL('licence/id')],
+			);
 	});
 });

--- a/test/select.js
+++ b/test/select.js
@@ -15,29 +15,18 @@ test('/pilot?$select=name', (result) =>
 	it('should select name from pilot', () =>
 		expect(result).to.be.a.query.that.selects([pilotName]).from('pilot')));
 
-test('/pilot?$select=favourite_colour', (result) =>
-	it('should select favourite_colour from pilot', () =>
+test('/pilot?$select=favourite_colour', (result) => {
+	it('should select favourite_colour from pilot', () => {
 		expect(result)
 			.to.be.a.query.that.selects(
 				_.filter(pilotFields, { 2: 'favourite_colour' }),
 			)
-			.from('pilot')));
+			.from('pilot');
+	});
+});
 
-test('/pilot(1)?$select=favourite_colour', (result) =>
-	it('should select from pilot with id', () =>
-		expect(result)
-			.to.be.a.query.that.selects(
-				_.filter(pilotFields, { 2: 'favourite_colour' }),
-			)
-			.from('pilot')
-			.where([
-				'IsNotDistinctFrom',
-				['ReferencedField', 'pilot', 'id'],
-				['Bind', 0],
-			])));
-
-test("/pilot('TextKey')?$select=favourite_colour", (result) =>
-	it('should select from pilot with id', () =>
+test('/pilot(1)?$select=favourite_colour', (result) => {
+	it('should select from pilot with id', () => {
 		expect(result)
 			.to.be.a.query.that.selects(
 				_.filter(pilotFields, { 2: 'favourite_colour' }),
@@ -47,114 +36,165 @@ test("/pilot('TextKey')?$select=favourite_colour", (result) =>
 				'IsNotDistinctFrom',
 				['ReferencedField', 'pilot', 'id'],
 				['Bind', 0],
-			])));
+			]);
+	});
+});
 
-test('/pilot?$select=was_trained_by__pilot/name', (result) =>
-	it('should select name from pilot', () =>
+test("/pilot('TextKey')?$select=favourite_colour", (result) => {
+	it('should select from pilot with id', () => {
+		expect(result)
+			.to.be.a.query.that.selects(
+				_.filter(pilotFields, { 2: 'favourite_colour' }),
+			)
+			.from('pilot')
+			.where([
+				'IsNotDistinctFrom',
+				['ReferencedField', 'pilot', 'id'],
+				['Bind', 0],
+			]);
+	});
+});
+
+test('/pilot?$select=was_trained_by__pilot/name', (result) => {
+	it('should select name from pilot', () => {
 		expect(result)
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'was trained by'),
 			)
-			.from('pilot', ['pilot', 'pilot.was trained by-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'was trained by-pilot'],
-				['ReferencedField', 'pilot.was trained by-pilot', 'id'],
-			])));
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.was trained by-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'was trained by-pilot'],
+					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+				],
+			])
+			.where();
+	});
+});
 
-test('/pilot?$select=trained__pilot/name', (result) =>
-	it('should select name from pilot', () =>
+test('/pilot?$select=trained__pilot/name', (result) => {
+	it('should select name from pilot', () => {
 		expect(result)
 			.to.be.a.query.that.selects(aliasFields('pilot', [pilotName], 'trained'))
-			.from('pilot', ['pilot', 'pilot.trained-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'id'],
-				['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-			])));
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.trained-pilot'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'id'],
+					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+				],
+			])
+			.where();
+	});
+});
 
-test('/pilot?$select=was_trained_by__pilot/name,trained__pilot/name', (result) =>
-	it('should select name from pilot', () =>
+test('/pilot?$select=was_trained_by__pilot/name,trained__pilot/name', (result) => {
+	it('should select name from pilot', () => {
 		expect(result)
 			.to.be.a.query.that.selects(
 				aliasFields('pilot', [pilotName], 'was trained by').concat(
 					aliasFields('pilot', [pilotName], 'trained'),
 				),
 			)
-			.from(
-				'pilot',
-				['pilot', 'pilot.was trained by-pilot'],
-				['pilot', 'pilot.trained-pilot'],
-			)
-			.where([
-				'And',
+			.from('pilot')
+			.leftJoin(
 				[
-					'Equals',
-					['ReferencedField', 'pilot', 'was trained by-pilot'],
-					['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+					['pilot', 'pilot.was trained by-pilot'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'was trained by-pilot'],
+						['ReferencedField', 'pilot.was trained by-pilot', 'id'],
+					],
 				],
+				[
+					['pilot', 'pilot.trained-pilot'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
+					],
+				],
+			)
+			.where();
+	});
+});
+
+test('/pilot?$select=trained__pilot/name,age', (result) => {
+	it('should select name, age from pilot', () => {
+		expect(result)
+			.to.be.a.query.that.selects(
+				aliasFields('pilot', [pilotName], 'trained').concat([pilotAge]),
+			)
+			.from('pilot')
+			.leftJoin([
+				['pilot', 'pilot.trained-pilot'],
 				[
 					'Equals',
 					['ReferencedField', 'pilot', 'id'],
 					['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
 				],
-			])));
+			])
+			.where();
+	});
+});
 
-test('/pilot?$select=trained__pilot/name,age', (result) =>
-	it('should select name, age from pilot', () =>
-		expect(result)
-			.to.be.a.query.that.selects(
-				aliasFields('pilot', [pilotName], 'trained').concat([pilotAge]),
-			)
-			.from('pilot', ['pilot', 'pilot.trained-pilot'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'id'],
-				['ReferencedField', 'pilot.trained-pilot', 'was trained by-pilot'],
-			])));
+test('/pilot?$select=*', (result) => {
+	it('should select * from pilot', () => {
+		expect(result).to.be.a.query.that.selects(pilotFields).from('pilot');
+	});
+});
 
-test('/pilot?$select=*', (result) =>
-	it('should select * from pilot', () =>
-		expect(result).to.be.a.query.that.selects(pilotFields).from('pilot')));
-
-test('/pilot?$select=licence/id', (result) =>
-	it('should select licence/id for pilots', () =>
+test('/pilot?$select=licence/id', (result) => {
+	it('should select licence/id for pilots', () => {
 		expect(result)
 			.to.be.a.query.that.selects([operandToAbstractSQL('licence/id')])
-			.from('pilot', ['licence', 'pilot.licence'])
-			.where([
-				'Equals',
-				['ReferencedField', 'pilot', 'licence'],
-				['ReferencedField', 'pilot.licence', 'id'],
-			])));
+			.from('pilot')
+			.leftJoin([
+				['licence', 'pilot.licence'],
+				[
+					'Equals',
+					['ReferencedField', 'pilot', 'licence'],
+					['ReferencedField', 'pilot.licence', 'id'],
+				],
+			])
+			.where();
+	});
+});
 
-test('/pilot?$select=can_fly__plane/plane/id', (result) =>
-	it('should select can_fly__plane/plane/id for pilots', () =>
+test('/pilot?$select=can_fly__plane/plane/id', (result) => {
+	it('should select can_fly__plane/plane/id for pilots', () => {
 		expect(result)
 			.to.be.a.query.that.selects([
 				operandToAbstractSQL('can_fly__plane/plane/id'),
 			])
-			.from(
-				'pilot',
-				['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
-				['plane', 'pilot.pilot-can fly-plane.plane'],
+			.from('pilot')
+			.leftJoin(
+				[
+					['pilot-can fly-plane', 'pilot.pilot-can fly-plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot', 'id'],
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
+					],
+				],
+				[
+					['plane', 'pilot.pilot-can fly-plane.plane'],
+					[
+						'Equals',
+						['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
+						['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
+					],
+				],
 			)
-			.where([
-				'And',
-				[
-					'Equals',
-					['ReferencedField', 'pilot', 'id'],
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'pilot'],
-				],
-				[
-					'Equals',
-					['ReferencedField', 'pilot.pilot-can fly-plane', 'can fly-plane'],
-					['ReferencedField', 'pilot.pilot-can fly-plane.plane', 'id'],
-				],
-			])));
+			.where();
+	});
+});
 
-test('/copilot?$select=*', (result) =>
-	it('should select * from copilot', () =>
+test('/copilot?$select=*', (result) => {
+	it('should select * from copilot', () => {
 		expect(result).to.be.a.query.to.deep.equal([
 			'SelectQuery',
 			[
@@ -196,10 +236,12 @@ test('/copilot?$select=*', (result) =>
 					'copilot',
 				],
 			],
-		])));
+		]);
+	});
+});
 
-test('/copilot?$select=id,is_blocked,rank', (result) =>
-	it('should select * from copilot', () =>
+test('/copilot?$select=id,is_blocked,rank', (result) => {
+	it('should select * from copilot', () => {
 		expect(result).to.be.a.query.to.deep.equal([
 			'SelectQuery',
 			[
@@ -229,4 +271,6 @@ test('/copilot?$select=id,is_blocked,rank', (result) =>
 					'copilot',
 				],
 			],
-		])));
+		]);
+	});
+});


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/Fix-removal-of-rows-with-null-values-when-sorting-by-an-associated-resource-984
See: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/160#discussion_r1999167402
